### PR TITLE
No observance shift for Sweden

### DIFF
--- a/calendra/europe.py
+++ b/calendra/europe.py
@@ -93,6 +93,8 @@ class Sweden(WesternCalendar, ChristianMixin):
     include_christmas_eve = True
     include_boxing_day = True
     boxing_day_label = "Second Day of Christmas"
+    
+    observance_shift = None
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
         (5, 1, "Labour Day"),


### PR DESCRIPTION
There is no observance observance shift in Sweden.

I.e. the following is currently wrong:

```
from calendra.europe import Sweden
from datetime import date

> cal = Sweden()
> christmas_eve = date(2015,12,24)
> cal.add_working_days(christmas_eve, 1)
< datetime.date(2015, 12, 29) # should be December 28
> cal.is_observed_holiday(date(2015,12,28))
< True
```

Setting `observance_shift = None` for `Sweden` fixes this issue.