### PR TITLE
Sync workalendar v5.2.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,37 @@ refs #
 
 <!-- if your contribution is a new calendar -->
 
-For information, read and make sure you're okay with the [CONTRIBUTING document](https://github.com/novafloss/workalendar/blob/master/CONTRIBUTING.rst#adding-new-calendars).
+For information, read and make sure you're okay with the [Contributing guidelines](https://github.com/novafloss/workalendar/blob/master/contributing.md#adding-new-calendars).
 
 - [ ] Tests with a significant number of years to be tested for your calendar.
 - [ ] Docstrings for the Calendar class and specific methods.
-- [ ] Calendar country / label added to the README.rst file,
-- [ ] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)"
+- [ ] Use the ``workalendar.registry_tools.iso_register`` decorator to register your new calendar using ISO codes (optional).
+- [ ] Calendar country / label added to the README.rst file.
+- [ ] Changelog amended with a mention like: "Added ``<country>`` by ``@pseudo`` (#)". **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
 
 <!-- if your contribution is a fix -->
 
 - [ ] Tests with a significant number of years to be tested for your calendar.
-- [ ] Changelog amended with a mention describing your changes.
+- [ ] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
+
+<!-- Release management
+
+- Commit for the tag:
+    - [ ] Edit version in setup.py
+    - [ ] Add version in Changelog.md ; trim things
+    - [ ] Push & wait for the tests to be green
+    - [ ] tag me.
+    - [ ] build sdist + wheel packages (``make package``)
+- Back to dev commit:
+    - [ ] Edit version in setup.py
+    - [ ] Add the "master / nothing to see here" in Changelog.md
+    - [ ] Push & wait for the tests to be green
+- [ ] Merge --ff
+- Github stuff
+    - [ ] Push tag in Github
+    - [ ] Edit release on Github using the changelog.
+    - [ ] Delete branch
+- [ ] upload release on PyPI using ``twine``
+- [ ] (*optional*) Make feeback on the various PR or issues.
+
+ -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: xenial
 sudo: false
-dist: xenial
 language: python
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 sudo: false
+dist: xenial
 language: python
 
 python:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,144 @@
+
+4.0
+---
+
+Incorporate changes from workalendar v5.2.2. (2019-07-07)
+
+- Fix Denmark, remove observances (remove Palm Sunday, Constitution Day, Christmas Eve and New Year's Eve) (#387, #386)
+
+Incorporate changes from workalendar v5.2.1 (2019-07-05)
+    
+- Refactored the package building procedure, now linked to `make package` ; added a note about this target in the PR template (#366).
+- Fixed United Kingom's 2020 holidays ; The Early May Bank Holiday has been moved to May 8th to commemorate the 75th anniversary of the end of WWII (#381).
+
+Incorporate changes from workalendar v5.2.0 (2019-07-04)
+
+- New Calendar
+
+    - Added JapanBank by @raybuhr (#379, #369).
+
+- Other changes
+
+    - Added adjustments to 2019-2020 Japan calendar due to the coronation of a new emperor (#379).
+    - Add a note about the fact that contributors should not change the version number in the changelog and/or the ``setup.py`` file (#380).
+
+Incorporate changes from workalendar v5.1.1 (2019-06-27)
+
+- Display missing lines in coverage report (#376).
+- Add "Europe Day" for Luxembourg (#377).
+
+Incorporate changes from workalendar v5.1.0 (2019-06-24)
+
+- **Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next major release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
+
+- New Calendar
+
+    - Added Turkey by @tayyipgoren (#371).
+
+- Other changes
+
+    - Change registry mechanism to avoid circular imports (#288).
+    - Internal: Added a "Release" section to the Pull Request template.
+    - Internal: Added advices on the Changelog entry in the Contributing document.
+    - Bugfix: Fixing North Carolina shift rules when Christmas Day happens on Saturday (#232).
+    - Documentation: rearrange country list in ``README.rst`` (sorting and fixing nested lists).
+    - Documentation: Renamed and changed format of the "Contributing guidelines" document, now in Markdown (GFM variant), with a few fixes (#368).
+    - Internal: remove coverage targets ; now coverage reports are displayed for each tox job, but they won't output classes with 100% coverage.
+
+Incorporate changes from workalendar v5.0.3 (2019-06-07)
+
+- Bugfix: Panama - Fixed incorrect independence from Spain date, thanks to @chopanpma (#361).
+
+Incorporate changes from workalendar v5.0.2 (2019-06-03)
+
+- Bugfix: Israel - Fixed incorrect Purim/Shushan Purim dates in jewish leap years, thx @orzarchi. This fix cancels the last (5.0.1) version, that will be deleted from PyPI.
+
+Incorporate changes from workalendar v5.0.1 (2019-06-03)
+
+- **WARNING** This version contains known bugs on Israel calendar. Please do not use it in production.
+
+- Bugfix: Israel - Fixed incorrect Purim/Shushan Purim dates in jewish leap years, thx @orzarchi.
+
+Incorporate changes from workalendar v5.0.0 (2019-05-24)
+
+- Major Changes & fixes
+
+    - Dropped Python 3.4 support (#352).
+    - Added Malaysia Thaipusam days for the year 2019 & 2020 - thx @burlak for the bug report (#354).
+    - Fixed Deepavali dates for the year 2018 ; confirmed fixed dates that were set in the past.
+
+- Added calendars
+
+    - Added Florida specific calendars: Florida Legal, Florida Circuit Courts, Miami-Dade (#216).
+
+Incorporate changes from workalendar v4.4.0 (2019-05-17)
+
+- **WARNING**: This release will be the last one to support Python 3.4, which has [reached its End of Life and has been retired](https://www.python.org/dev/peps/pep-0429/#release-schedule). Please upgrade.
+
+- Added calendar
+
+    - Added California specific calendars: California Education, Berkeley, San Francisco, West Hollywood (#215).
+
+- Fixes
+
+    - Added a few refactors and tests for Australia Capital Territory holiday named "Family & Community Day", that lasted from 2007 to 2017 (#25).
+    - Added South African 2019 National Elections as holiday (#350), by @RichardOB.
+
+Incorporate changes from workalendar v4.3.1 (2019-05-03)
+
+- Bugfix: Update 2019 Labour Day Holidays for China as changed by government recently (2019-03-22), by @iamsk, and thanks to @ltyely for their patch (#345 & #347).
+
+Incorporate changes from workalendar v4.3.0 (2019-03-15)
+
+- New Calendar
+
+    - Added Barbados by @ludsoft.
+
+- Fixes
+
+    - Added isolated tests for shifting mechanics in USA calendars - previously untested (#335).
+    - Added Berlin specific holidays (#340).
+    - Added several one-off public holidays to UK calendar (#336).
+
+Incorporate changes from workalendar v4.2.0 (2019-02-21)
+
+- New calendars
+
+    - Added several US territories and other specific calendars:
+
+        - American Samoa territory (#218).
+        - Chicago, Illinois (#220).
+        - Guam territory (#219).
+        - Suffolk County, Massachusetts (#222).
+
+    - Added Cayman Islands, British Overseas Territory (#328)
+
+Incorporate changes from workalendar v4.1.0 (2019-02-07)
+
+- New calendars
+
+- **WARNING** Scotland (sub)calendars are highly experimental and because of their very puzzling rules, may be false. Please use them with care.
+
+    - Added Scotland calendars, i.e. Scotland, Aberdeen, Angus, Arbroath, Ayr, Carnoustie & Monifieth, Clydebank, Dumfries & Galloway, Dundee, East Dunbartonshire, Edinburgh, Elgin, Falkirk, Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock, Lochaber, Monifieth, North Lanarkshire, Paisley, Perth, Scottish Borders, South Lanarkshire, Stirling, and West Dunbartonshire (#31).
+
+- Bugfixes
+
+    - Fixed United Kingdom bank holiday for 2002 and 2012, thx @ludsoft (#315).
+    - Fix a small flake8 issue with wrong indentation (#319).
+    - Fix Russia "Day of Unity" date, set to November 4th, thx @alexitkes for the bug report (#317).
+
+Incorporate changes from workalendar v4.0.0 (2019-01-24)
+
+- Solved the incompatibility between `pandas` latest version and Python 3.4. Upgraded travis distro to Xenial/16.04 LTS (#307).
+- Added instructions about the usage of the `iso_register` decorator in the pull-request template (#309).
+
+- New Calendars
+
+    - Added New Zealand, by @johnguant (#306).
+    - Added Paraguay calendar, following the work of @reichert (#268).
+    - Added China calendar, by @iamsk (#304).
+    - Added Israel, by @armona, @tsehori (#281).
+
 3.0
 ---
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,8 +30,6 @@ Incorporate changes from workalendar v5.1.1 (2019-06-27)
 
 Incorporate changes from workalendar v5.1.0 (2019-06-24)
 
-- **Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next major release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
-
 - New Calendar
 
     - Added Turkey by @tayyipgoren (#371).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,11 @@
 
 Incorporate changes from workalendar v5.2.2. (2019-07-07)
 
+- **Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next major release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
 - Fix Denmark, remove observances (remove Palm Sunday, Constitution Day, Christmas Eve and New Year's Eve) (#387, #386)
 
 Incorporate changes from workalendar v5.2.1 (2019-07-05)
-    
+
 - Refactored the package building procedure, now linked to `make package` ; added a note about this target in the PR template (#366).
 - Fixed United Kingom's 2020 holidays ; The Early May Bank Holiday has been moved to May 8th to commemorate the 75th anniversary of the end of WWII (#381).
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -274,8 +274,11 @@ Syncing from upstream Workalendar
 
     git diff 5.2.2..HEAD
 
-6. Proceed with care, and test as needed::
+6. Merge, based on the diff command above, and a careful review/tweaking
+   of the results.
+
+7. Proceed with care, and test as needed::
 
     tox
 
-7. Generate a PR when ready!
+8. Generate a PR when ready!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -249,3 +249,33 @@ contribute to the core of the library by adding some new Mixins or Calendars.
 
 Bear in mind that the code you'd provide **must** be tested using unittests
 before you submit your pull-request.
+
+Syncing from upstream Workalendar
+=================================
+
+1. Create a fork, and clone it::
+
+    git clone git@github.com:ShaheedHaque/calendra.git
+
+2. Add a remote pointing to upstream Workalendar::
+
+    cd calendra
+    git remote add workalendar git@github.com:peopledoc/workalendar.git
+
+3. Pull the remote, including its tags::
+
+    git remote update
+
+4. Make a branch to work on::
+
+    git checkout -b srh_sync_workalendar_5_2_2
+
+5. Review the changes to be brought in::
+
+    git diff 5.2.2..HEAD
+
+6. Proceed with care, and test as needed::
+
+    tox
+
+7. Generate a PR when ready!

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,8 @@ else
 	${TOX_COMMAND}  -- ${TEST_ARGS}
 endif
 
-# target: wheel_install - install wheel in your current environment
-wheel_install:
-	pip install wheel
-
-# target: pypi - upload current version on PYPI
-.PHONY: pypi
-pypi: wheel_install
-	python setup.py sdist bdist_wheel upload
+# target: package - build packages for further upload
+.PHONY: package
+package:
+	rm -Rf build/
+	python setup.py sdist bdist_wheel

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,8 @@ Status
 The project is stable and in production use. Calendra follows the principles
 of `semver <https://semver.org>`_ for released verisons.
 
+If you spot any bug or wish to add a calendar, please refer to the `Contributing doc <CONTRIBUTING.rst>`_.
+
 Usage sample
 ============
 
@@ -81,7 +83,7 @@ External dependencies
 You may want to install ``python-dev`` and/or ``python3-dev`` on your machine to
 either run the installation or run tests via tox.
 
-Workalendar has been tested on Python 2.7, 3.4, 3.5, 3.6, 3.7.
+Workalendar has been tested on Python 2.7, 3.5, 3.6, 3.7.
 
 Tests
 =====
@@ -107,6 +109,7 @@ Europe
 * Austria
 * Belgium
 * Bulgaria
+* Cayman Islands
 * Croatia
 * Cyprus
 * Czech Republic
@@ -133,29 +136,45 @@ Europe
 * Romania
 * Russia
 * Slovakia
-* Sweden
-* United Kingdom (incl. Northern Ireland)
-* Spain (incl. Catalonia)
 * Slovenia
+* Spain (incl. Catalonia)
+* Sweden
 * Switzerland
+
   * Vaud
+
+* Turkey
+* United Kingdom (incl. Northern Ireland, Scotland and all its territories)
 
 America
 -------
 
+* Barbados
 * Brazil (all states, cities and for bank transactions, except the city of Viana)
+* Canada (including provincial and territory holidays)
 * Chile
 * Colombia
 * Mexico
 * Panama
-* United States of America (including state holidays)
-* Canada (including provincial and territory holidays)
+* Paraguay
+* United States of America
+
+  * State holidays for all the 50 States
+  * American Samoa
+  * Chicago, Illinois
+  * Guam
+  * Suffolk County, Massachusetts
+  * California Education, Berkeley, San Francisco, West Hollywood
+  * Florida Legal and Florida Circuit Courts, Miami-Dade
 
 Asia
 ----
 
+* China
 * Hong Kong
+* Israel
 * Japan
+* JapanBank
 * Malaysia
 * Qatar
 * Singapore
@@ -167,6 +186,7 @@ Oceania
 
 * Australia (incl. its different states)
 * Marshall Islands
+* New Zealand
 
 Africa
 ------

--- a/calendra/africa/algeria.py
+++ b/calendra/africa/algeria.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, IslamicMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('DZ')

--- a/calendra/africa/angola.py
+++ b/calendra/africa/angola.py
@@ -2,9 +2,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from datetime import timedelta
-from ..core import WesternCalendar
 from ..core import ChristianMixin
-from ..registry import iso_register
+from ..core import WesternCalendar
+from ..registry_tools import iso_register
 
 
 @iso_register('AO')

--- a/calendra/africa/benin.py
+++ b/calendra/africa/benin.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, IslamicMixin, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BJ')

--- a/calendra/africa/ivory_coast.py
+++ b/calendra/africa/ivory_coast.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, IslamicMixin, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CI')

--- a/calendra/africa/madagascar.py
+++ b/calendra/africa/madagascar.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MG')

--- a/calendra/africa/sao_tome.py
+++ b/calendra/africa/sao_tome.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('ST')

--- a/calendra/africa/south_africa.py
+++ b/calendra/africa/south_africa.py
@@ -8,7 +8,7 @@ from ..core import WesternCalendar
 from ..core import MON, FRI
 from ..core import ChristianMixin
 from ..exceptions import CalendarError
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('ZA')
@@ -152,5 +152,7 @@ class SouthAfrica(WesternCalendar, ChristianMixin):
             days.append((date(year, 5, 7), "National Elections"))
         if year == 2016:
             days.append((date(year, 8, 3), "Local Elections"))
+        if year == 2019:
+            days.append((date(year, 5, 8), "National Elections"))
 
         return days

--- a/calendra/america/__init__.py
+++ b/calendra/america/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from .barbados import Barbados
 from .brazil import (
     Brazil, BrazilAcre, BrazilAlagoas, BrazilAmapa, BrazilAmazonas,
     BrazilBahia, BrazilCeara, BrazilDistritoFederal, BrazilEspiritoSanto,
@@ -15,14 +16,15 @@ from .canada import (
     NewBrunswick, NovaScotia, PrinceEdwardIsland, Newfoundland, Yukon,
     NorthwestTerritories, Nunavut
 )
-
 from .chile import Chile
 from .colombia import Colombia
 from .mexico import Mexico
 from .panama import Panama
+from .paraguay import Paraguay
 
 
 __all__ = (
+    # Brazil & its states.
     'Brazil',
     'BrazilAcre',
     'BrazilAlagoas',
@@ -72,8 +74,10 @@ __all__ = (
     'NorthwestTerritories',
     'Nunavut',
     # Other american countries
+    'Barbados',
     'Chile',
     'Colombia',
     'Mexico',
     'Panama',
+    'Paraguay',
 )

--- a/calendra/america/barbados.py
+++ b/calendra/america/barbados.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, division, print_function
+from datetime import timedelta
+from copy import copy
+
+from ..core import WesternCalendar, ChristianMixin
+from ..core import SUN, MON
+from ..registry_tools import iso_register
+
+
+@iso_register("BB")
+class Barbados(WesternCalendar, ChristianMixin):
+    "Barbados"
+
+    include_good_friday = True
+    include_easter_sunday = True
+    include_easter_monday = True
+    include_whit_monday = True
+    include_boxing_day = True
+
+    # All holiday are shifted if on a Sunday
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 21, "Errol Barrow Day"),
+        (4, 28, "National Heroes Day"),
+        (5, 1, "Labour Day"),
+        (8, 1, "Emancipation Day"),
+        (11, 30, "Independance Day"),
+    )
+
+    def get_kadooment_day(self, year):
+        """
+        First Monday of August.
+        """
+        return (Barbados.get_nth_weekday_in_month(year, 8, MON),
+                "Kadooment Day")
+
+    def get_variable_days(self, year):
+        """
+        Return variable holidays of the Barbados calendar.
+        """
+        days = super(Barbados, self).get_variable_days(year)
+        days.append(self.get_kadooment_day(year))
+        return days
+
+    def get_fixed_holidays(self, year):
+        """
+        Return fixed holidays of the Barbados calendar.
+
+        A shift day is appended if a fixed holiday happens on SUN.
+        """
+        days = super(Barbados, self).get_fixed_holidays(year)
+        days_to_shift = copy(days)
+        for day, label in days_to_shift:
+            if day.weekday() == SUN:
+                days.append(
+                    (day + timedelta(days=1), "%s %s" % (label, "(shifted)"))
+                )
+        return days

--- a/calendra/america/brazil.py
+++ b/calendra/america/brazil.py
@@ -6,7 +6,7 @@ from datetime import timedelta, date
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, SAT, SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BR')

--- a/calendra/america/canada.py
+++ b/calendra/america/canada.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin, Calendar
 from ..core import SUN, MON, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CA')

--- a/calendra/america/chile.py
+++ b/calendra/america/chile.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, TUE, WED, FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CL')

--- a/calendra/america/colombia.py
+++ b/calendra/america/colombia.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import timedelta, date
 
 from ..core import WesternCalendar, ChristianMixin, MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CO')

--- a/calendra/america/mexico.py
+++ b/calendra/america/mexico.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import SUN, MON, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MX')

--- a/calendra/america/panama.py
+++ b/calendra/america/panama.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import timedelta
 
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PA')
@@ -21,7 +21,7 @@ class Panama(WesternCalendar, ChristianMixin):
         (11, 3, "Independence Day"),
         (11, 5, "Colon Day"),
         (11, 10, "Shout in Villa de los Santos"),
-        (12, 2, "Independence from Spain"),
+        (11, 28, "Independence from Spain"),
         (12, 8, "Mothers' Day"),
     )
 

--- a/calendra/america/paraguay.py
+++ b/calendra/america/paraguay.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from datetime import date
+
+from ..core import WesternCalendar, ChristianMixin
+from ..registry_tools import iso_register
+
+
+@iso_register('PY')
+class Paraguay(WesternCalendar, ChristianMixin):
+    "Paraguay"
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (5, 1, "Labour Day"),
+        (5, 14, "Independence Day"),
+        (6, 12, "Chaco Armistice"),
+        (9, 19, "Army holiday"),
+        (12, 8, "Virgin of Caacupé Day"),
+    )
+    include_holy_thursday = True
+    include_good_friday = True
+    include_easter_saturday = True
+
+    def get_heroes_day(self, year):
+        """
+        Heroes Day is a fixed holidays.
+
+        In 2017, it has been moved to February 27th ; otherwise, it happens on
+        March 1st.
+
+        ref: https://en.wikipedia.org/wiki/Public_holidays_in_Paraguay
+        """
+        label = "Heroes' Day"
+        if year == 2017:
+            day = date(year, 2, 27)
+        else:
+            day = date(year, 3, 1)
+        return (day, label)
+
+    def get_founding_of_asuncion(self, year):
+        """
+        Return the Founding of Asunción.
+
+        In 2017, it has been moved to August 14th ; otherwise it happens on
+        August 15th.
+        """
+        label = "Founding of Asunción"
+        if year == 2017:
+            day = date(year, 8, 14)
+        else:
+            day = date(year, 8, 15)
+        return (day, label)
+
+    def get_boqueron_battle_victory_day(self, year):
+        """
+        Return Boqueron Battle Victory Day.
+
+        In 2017, it has been moved to October 2nd ; otherwise it happens on
+        September 29th.
+        """
+        label = "Boqueron Battle Victory Day"
+        if year == 2017:
+            day = date(year, 10, 2)
+        else:
+            day = date(year, 9, 29)
+        return (day, label)
+
+    def get_fixed_holidays(self, year):
+        """
+        Return fixed holidays for Paraguay.
+        """
+        days = super(Paraguay, self).get_fixed_holidays(year)
+        days.append(self.get_heroes_day(year))
+        days.append(self.get_founding_of_asuncion(year))
+        days.append(self.get_boqueron_battle_victory_day(year))
+        return days

--- a/calendra/asia/__init__.py
+++ b/calendra/asia/__init__.py
@@ -1,19 +1,24 @@
 # -*- coding: utf-8 -*-
+from .china import China
 from .hong_kong import HongKong
-from .japan import Japan
+from .japan import Japan, JapanBank
 from .malaysia import Malaysia
 from .qatar import Qatar
 from .singapore import Singapore
 from .south_korea import SouthKorea
 from .taiwan import Taiwan
+from .israel import Israel
 
 
 __all__ = (
+    'China',
     'HongKong',
     'Japan',
+    'JapanBank',
     'Malaysia',
     'Qatar',
     'Singapore',
     'SouthKorea',
     'Taiwan',
+    'Israel',
 )

--- a/calendra/asia/china.py
+++ b/calendra/asia/china.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from datetime import date
+import warnings
+
+from ..core import ChineseNewYearCalendar, WesternCalendar
+from ..registry_tools import iso_register
+from ..exceptions import CalendarError
+
+holidays = {
+    2018:
+        {
+            'Ching Ming Festival': [(4, 5), (4, 6), (4, 7)],
+            'Labour Day Holiday': [(4, 29), (4, 30), (5, 1)],
+            'Dragon Boat Festival': [(6, 18)],
+            'Mid-Autumn Festival': [(9, 24)],
+            'New year': [(12, 30), (12, 31)]
+        },
+    2019:
+        {
+            'Ching Ming Festival': [(4, 5)],
+            'Labour Day Holiday': [(5, 1), (5, 2), (5, 3)],
+            'Dragon Boat Festival': [(6, 7)],
+            'Mid-Autumn Festival': [(9, 13)]
+        },
+}
+
+workdays = {
+    2018:
+        {
+            'Spring Festival Shift': [(2, 11), (2, 24)],
+            'Ching Ming Festival Shift': [(4, 8)],
+            'Labour Day Holiday Shift': [(4, 28)],
+            'National Day Shift': [(9, 29), (9, 30)],
+            'New year Shift': [(12, 29)]
+        },
+    2019:
+        {
+            'Spring Festival Shift': [(2, 2), (2, 3)],
+            'Labour Day Holiday Shift': [(4, 28), (5, 5)],
+            'National Day Shift': [(9, 29), (10, 12)],
+        },
+}
+
+
+@iso_register('CN')
+class China(ChineseNewYearCalendar, WesternCalendar):
+    "China"
+    # WARNING: Support 2018, 2019 currently, need update every year.
+    # National Days, 10.1 - 10.7
+    national_days = [(10, i, "National Day") for i in range(1, 8)]
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + tuple(national_days)
+
+    include_chinese_new_year_eve = True
+
+    extra_working_days = []
+    for year, data in workdays.items():
+        for holiday_name, day_list in data.items():
+            for v in day_list:
+                extra_working_days.append(date(year, v[0], v[1]))
+
+    def get_calendar_holidays(self, year):
+        warnings.warn("Support 2018, 2019 currently, need update every year.")
+        if year not in holidays.keys():
+            msg = "Need configure {} for China.".format(year)
+            raise CalendarError(msg)
+        return super(China, self).get_calendar_holidays(year)
+
+    def get_variable_days(self, year):
+        days = super(China, self).get_variable_days(year)
+        # Spring Festival, eve, 1.1, and 1.2 - 1.6 in lunar day
+        for i in range(2, 7):
+            days.append((ChineseNewYearCalendar.lunar(year, 1, i),
+                         "Spring Festival"))
+        # other holidays
+        for holiday_name, day_list in holidays[year].items():
+            for v in day_list:
+                days.append((date(year, v[0], v[1]), holiday_name))
+        return days
+
+    def is_working_day(self, day,
+                       extra_working_days=None, extra_holidays=None):
+        extra_working_days = extra_working_days or self.extra_working_days
+        return super(China, self).is_working_day(day, extra_working_days,
+                                                 extra_holidays)
+
+    def add_working_days(self, day, delta,
+                         extra_working_days=None, extra_holidays=None,
+                         keep_datetime=False):
+        extra_working_days = extra_working_days or self.extra_working_days
+        return super(China, self).add_working_days(day, delta,
+                                                   extra_working_days,
+                                                   extra_holidays,
+                                                   keep_datetime)
+
+    def sub_working_days(self, day, delta,
+                         extra_working_days=None, extra_holidays=None,
+                         keep_datetime=False):
+        extra_working_days = extra_working_days or self.extra_working_days
+        return super(China, self).sub_working_days(day, delta,
+                                                   extra_working_days,
+                                                   extra_holidays,
+                                                   keep_datetime)

--- a/calendra/asia/hong_kong.py
+++ b/calendra/asia/hong_kong.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..core import ChristianMixin, EphemMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('HK')

--- a/calendra/asia/israel.py
+++ b/calendra/asia/israel.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, unicode_literals)
+from datetime import date, timedelta
+
+from pyluach.dates import GregorianDate, HebrewDate
+
+from ..core import Calendar, FRI, SAT
+from ..registry_tools import iso_register
+
+
+@iso_register("IL")
+class Israel(Calendar):
+    "Israel"
+
+    WEEKEND_DAYS = (SAT, FRI)
+
+    def get_variable_days(self, year):
+        days = super(Israel, self).get_variable_days(year)
+
+        delta = timedelta(days=1)
+        current_date = date(year, 1, 1)
+
+        while current_date.year == year:
+            hebrew_date = GregorianDate(
+                year=current_date.year,
+                month=current_date.month,
+                day=current_date.day,
+            ).to_heb()
+
+            jewish_year = hebrew_date.year
+            month = hebrew_date.month
+            day = hebrew_date.day
+
+            if month == 7:
+                if day in {1, 2, 3}:
+                    days.append((current_date, "Rosh Hashana"))
+                elif day == 10:
+                    days.append((current_date, "Yom Kippur"))
+                elif day in range(15, 22):
+                    days.append((current_date, "Sukkot"))
+                elif day == 22:
+                    days.append((current_date, "Shmini Atzeres"))
+            elif month == 12 and not HebrewDate._is_leap(jewish_year):
+                if day == 14:
+                    days.append((current_date, "Purim"))
+                if day == 15:
+                    days.append((current_date, "Shushan Purim"))
+            elif month == 13:
+                if day == 14:
+                    days.append((current_date, "Purim"))
+                elif day == 15:
+                    days.append((current_date, "Shushan Purim"))
+            elif month == 1 and day in {15, 21}:
+                days.append((current_date, "Pesach"))
+            elif month == 2:
+                if day == 5:
+                    if hebrew_date.weekday() == 6:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 4).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    elif hebrew_date.weekday() == 7:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 3).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    elif hebrew_date.weekday() == 2:
+                        days.append(
+                            (
+                                HebrewDate(jewish_year, month, 6).to_pydate(),
+                                "Independence Day",
+                            )
+                        )
+                    else:
+                        days.append((current_date, "Independence Day"))
+            elif month == 3 and day == 6:
+                days.append((current_date, "Shavout"))
+
+            current_date += delta
+
+        return days

--- a/calendra/asia/japan.py
+++ b/calendra/asia/japan.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from ..core import MON, EphemMixin
 from ..core import WesternCalendar
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('JP')
@@ -20,18 +20,40 @@ class Japan(WesternCalendar, EphemMixin):
         (5, 5, "Children's Day"),
         (11, 3, "Culture Day"),
         (11, 23, "Labour Thanksgiving Day"),
-        (12, 23, "The Emperor's Birthday"),
     )
 
     def get_fixed_holidays(self, year):
         """
         Fixed holidays for Japan.
-
-        As of 2016, the "Mountain Day is being added"
         """
         days = super(Japan, self).get_fixed_holidays(year)
         if year >= 2016:
             days.append((date(year, 8, 11), "Mountain Day"))
+        # Change in Emperor
+        if year < 2019:
+            days.append((date(year, 12, 23), "The Emperor's Birthday"))
+        if year > 2019:
+            days.append((date(year, 2, 23), "The Emperor's Birthday"))
+        # Lots of adjustments for new emperor
+        if year == 2019:
+            days.extend([
+                (date(year, 4, 30), "Coronation Day"),
+                (date(year, 5, 1), "Coronation Day"),
+                (date(year, 5, 2), "Coronation Day"),
+                (date(year, 5, 6), "Children's Day Observed"),
+                (date(year, 8, 12), "Mountain Day Observed"),
+                (date(year, 10, 22), "Enthronement Ceremony Day"),
+                (date(year, 11, 4), "Culture Day Observed"),
+            ])
+        if year == 2020:
+            days.extend([
+                (date(year, 2, 24), "The Emperor's Birthday Observed"),
+                (date(year, 5, 6), "Constitution Memorial Day Observed"),
+                (date(year, 8, 10), "Mountain Day"),
+            ])
+            # Mountain Day is 8/10 this year for some reason
+            # The next year that will be different is 2024
+            days.remove((date(year, 8, 11), "Mountain Day"))
         return days
 
     def get_variable_days(self, year):
@@ -50,4 +72,28 @@ class Japan(WesternCalendar, EphemMixin):
             (equinoxes[1], "Autumnal Equinox Day"),
             (health_and_sport, "Health and Sports Day"),
         ])
+
+        # Marine Day is on a Thursday in 2020 for some year
+        # https://www.timeanddate.com/holidays/japan/sea-day
+        # Health and Sports Day will continue on the 2nd monday
+        # of October, except in 2020 when it will happen in July
+        # https://www.timeanddate.com/holidays/japan/sports-day
+        if year == 2020:
+            days.remove((marine_day, "Marine Day"))
+            days.append((date(2020, 7, 23), "Marine Day"))
+            days.remove((health_and_sport, "Health and Sports Day"))
+            days.append((date(2020, 7, 24), "Health and Sports Day"))
         return days
+
+
+class JapanBank(Japan):
+    """The Bank of Japan is closed additional days other than
+    national holidays.
+    https://www.boj.or.jp/en/about/outline/holi.htm/
+    """
+
+    FIXED_HOLIDAYS = Japan.FIXED_HOLIDAYS + (
+        (1, 2, "New Year Bank Holiday"),
+        (1, 3, "New Year Bank Holiday"),
+        (12, 31, "New Year Bank Holiday"),
+    )

--- a/calendra/asia/malaysia.py
+++ b/calendra/asia/malaysia.py
@@ -5,7 +5,7 @@ from datetime import date
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..core import IslamicMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MY')
@@ -37,8 +37,8 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2015: date(2015, 11, 10),
         2016: date(2016, 10, 29),
         2017: date(2017, 10, 18),
-        2018: date(2018, 11, 7),   # This might change
-        2019: date(2019, 10, 27),  # This might change
+        2018: date(2018, 11, 6),
+        2019: date(2019, 10, 27),
         2020: date(2020, 11, 14),  # This might change
     }
 
@@ -51,7 +51,9 @@ class Malaysia(ChineseNewYearCalendar, WesternCalendar, IslamicMixin):
         2015: date(2015, 2, 3),
         2016: date(2016, 1, 25),
         2017: date(2017, 2, 9),
-        2018: date(2018, 1, 31),   # This might change
+        2018: date(2018, 1, 31),
+        2019: date(2019, 1, 21),
+        2020: date(2020, 2, 8),  # This might change
     }
     chinese_new_year_label = "First Day of Lunar New Year"
     include_chinese_second_day = True

--- a/calendra/asia/qatar.py
+++ b/calendra/asia/qatar.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import Calendar
 from ..core import FRI, SAT, IslamicMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('QA')

--- a/calendra/asia/singapore.py
+++ b/calendra/asia/singapore.py
@@ -6,7 +6,7 @@ from datetime import date
 from ..core import (
     ChineseNewYearCalendar, WesternCalendar, ChristianMixin, IslamicMixin
 )
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SG')

--- a/calendra/asia/south_korea.py
+++ b/calendra/asia/south_korea.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('KR')

--- a/calendra/asia/taiwan.py
+++ b/calendra/asia/taiwan.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
 from ..core import EphemMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('TW')

--- a/calendra/europe/__init__.py
+++ b/calendra/europe/__init__.py
@@ -2,6 +2,7 @@
 from .austria import Austria
 from .belgium import Belgium
 from .bulgaria import Bulgaria
+from .cayman_islands import CaymanIslands
 from .croatia import Croatia
 from .cyprus import Cyprus
 from .czech_republic import CzechRepublic
@@ -31,6 +32,7 @@ from .spain import Spain, Catalonia
 from .sweden import Sweden
 from .switzerland import Switzerland, Vaud
 from .united_kingdom import UnitedKingdom, UnitedKingdomNorthernIreland
+from .turkey import Turkey
 
 # Germany
 from .germany import (
@@ -40,12 +42,21 @@ from .germany import (
     SaxonyAnhalt, SchleswigHolstein, Thuringia
 )
 
+# Scotland
+from .scotland import (
+    Scotland, Aberdeen, Angus, Arbroath, Ayr, CarnoustieMonifieth, Clydebank,
+    DumfriesGalloway, Dundee, EastDunbartonshire, Edinburgh, Elgin, Falkirk,
+    Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock,
+    Lanark, Linlithgow, Lochaber, NorthLanarkshire, Paisley, Perth,
+    ScottishBorders, SouthLanarkshire, Stirling, WestDunbartonshire
+)
 
 __all__ = (
     'Austria',
     'Belgium',
     'Bulgaria',
     'Catalonia',
+    'CaymanIslands',
     'Croatia',
     'Cyprus',
     'CzechRepublic',
@@ -78,10 +89,19 @@ __all__ = (
     'Vaud',
     'UnitedKingdom',
     'UnitedKingdomNorthernIreland',
+    'Turkey',
 
     # Germany
     'Germany', 'BadenWurttemberg', 'Bavaria', 'Berlin', 'Brandenburg',
     'Bremen', 'Hamburg', 'Hesse', 'MecklenburgVorpommern', 'LowerSaxony',
     'NorthRhineWestphalia', 'RhinelandPalatinate', 'Saarland', 'Saxony',
     'SaxonyAnhalt', 'SchleswigHolstein', 'Thuringia',
+    # Scotland
+    'Scotland',
+    'Aberdeen', 'Angus', 'Arbroath', 'Ayr', 'CarnoustieMonifieth',
+    'Clydebank', 'DumfriesGalloway', 'Dundee', 'EastDunbartonshire',
+    'Edinburgh', 'Elgin', 'Falkirk', 'Fife', 'Galashiels', 'Glasgow',
+    'Hawick', 'Inverclyde', 'Inverness', 'Kilmarnock', 'Lanark', 'Linlithgow',
+    'Lochaber', 'NorthLanarkshire', 'Paisley', 'Perth', 'ScottishBorders',
+    'SouthLanarkshire', 'Stirling', 'WestDunbartonshire'
 )

--- a/calendra/europe/austria.py
+++ b/calendra/europe/austria.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('AT')

--- a/calendra/europe/belgium.py
+++ b/calendra/europe/belgium.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BE')

--- a/calendra/europe/bulgaria.py
+++ b/calendra/europe/bulgaria.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('BG')

--- a/calendra/europe/cayman_islands.py
+++ b/calendra/europe/cayman_islands.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from datetime import date, timedelta
+
+from ..core import WesternCalendar, ChristianMixin, MON, SAT
+from ..registry_tools import iso_register
+
+
+QUEENS_BIRTHDAY_EXCEPTIONS = {
+    2013: date(2013, 6, 17),
+    2017: date(2017, 6, 19),
+}
+
+
+@iso_register('KY')
+class CaymanIslands(WesternCalendar, ChristianMixin):
+    "Cayman Islands"
+    include_ash_wednesday = True
+    include_good_friday = True
+    include_easter_monday = True
+    include_boxing_day = True
+    shift_new_years_day = True
+
+    def get_variable_days(self, year):
+        days = super(CaymanIslands, self).get_variable_days(year)
+        days += [
+            (self.get_national_heroes_day(year), "National Heroes Day"),
+            (self.get_discovery_day(year), "Discovery Day"),
+            (self.get_queens_birthday(year), "Queen's Birthday"),
+            (self.get_constitution_day(year), "Constitution Day"),
+            (self.get_remembrance_day(year), "Remembrance Day"),
+        ]
+
+        shifts = self.shift_christmas_boxing_days(year=year)
+        days.extend(shifts)
+
+        if year == 2017:
+            days += [(date(2017, 5, 24), "Election day")]
+
+        return days
+
+    def get_national_heroes_day(self, year):
+        """Fourth Monday in January"""
+        return CaymanIslands.get_nth_weekday_in_month(year, 1, MON, 4)
+
+    def get_discovery_day(self, year):
+        """Third Monday in May"""
+        return CaymanIslands.get_nth_weekday_in_month(year, 5, MON, 3)
+
+    def get_queens_birthday(self, year):
+        """On monday after second saturday in June"""
+        sat = CaymanIslands.get_nth_weekday_in_month(year, 6, SAT, 2)
+        holiday = sat + timedelta(days=2)
+        return QUEENS_BIRTHDAY_EXCEPTIONS.get(year, holiday)
+
+    def get_constitution_day(self, year):
+        return CaymanIslands.get_nth_weekday_in_month(year, 7, MON, 1)
+
+    def get_remembrance_day(self, year):
+        return CaymanIslands.get_nth_weekday_in_month(year, 11, MON, 2)

--- a/calendra/europe/croatia.py
+++ b/calendra/europe/croatia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('HR')

--- a/calendra/europe/cyprus.py
+++ b/calendra/europe/cyprus.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import timedelta
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CY')

--- a/calendra/europe/czech_republic.py
+++ b/calendra/europe/czech_republic.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CZ')

--- a/calendra/europe/denmark.py
+++ b/calendra/europe/denmark.py
@@ -2,14 +2,13 @@
 from __future__ import unicode_literals
 from datetime import timedelta
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('DK')
 class Denmark(WesternCalendar, ChristianMixin):
     'Denmark'
 
-    include_palm_sunday = True
     include_holy_thursday = True
     include_good_friday = True
     include_easter_sunday = True
@@ -21,12 +20,6 @@ class Denmark(WesternCalendar, ChristianMixin):
     whit_monday_label = "Pentecost Monday"
     include_boxing_day = True
     boxing_day_label = "Second Day of Christmas"
-    include_christmas_eve = True
-
-    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (6, 5, "Constitution Day"),
-        (12, 31, "New Year's Eve")
-    )
 
     def get_store_bededag(self, year):  # 'great prayer day'
         easter_sunday = self.get_easter_sunday(year)

--- a/calendra/europe/estonia.py
+++ b/calendra/europe/estonia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('EE')

--- a/calendra/europe/finland.py
+++ b/calendra/europe/finland.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
 from ..core import FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('FI')

--- a/calendra/europe/france.py
+++ b/calendra/europe/france.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('FR')

--- a/calendra/europe/germany.py
+++ b/calendra/europe/germany.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date, timedelta
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('DE')
@@ -75,6 +75,22 @@ class Bavaria(Germany):
 @iso_register('DE-BE')
 class Berlin(Germany):
     'Berlin'
+
+    def get_international_womens_day(self, year):
+        day = date(year, 3, 8)
+        return (day, "International Women's Day")
+
+    def get_liberation_day(self, year):
+        day = date(year, 5, 8)
+        return (day, "Liberation Day")
+
+    def get_variable_days(self, year):
+        days = super(Berlin, self).get_variable_days(year)
+        if year >= 2019:
+            days.append(self.get_international_womens_day(year))
+        if year == 2020:
+            days.append(self.get_liberation_day(year))
+        return days
 
 
 @iso_register('DE-BB')

--- a/calendra/europe/greece.py
+++ b/calendra/europe/greece.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, OrthodoxMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('GR')

--- a/calendra/europe/hungary.py
+++ b/calendra/europe/hungary.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('HU')

--- a/calendra/europe/iceland.py
+++ b/calendra/europe/iceland.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
 from ..core import THU, MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('IS')

--- a/calendra/europe/ireland.py
+++ b/calendra/europe/ireland.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date, timedelta
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('IE')

--- a/calendra/europe/italy.py
+++ b/calendra/europe/italy.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('IT')

--- a/calendra/europe/latvia.py
+++ b/calendra/europe/latvia.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('LV')

--- a/calendra/europe/lithuania.py
+++ b/calendra/europe/lithuania.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from ..core import SUN
 
 

--- a/calendra/europe/luxembourg.py
+++ b/calendra/europe/luxembourg.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from datetime import date
+from ..registry_tools import iso_register
 
 
 @iso_register('LU')
@@ -19,3 +20,10 @@ class Luxembourg(WesternCalendar, ChristianMixin):
         (5, 1, "Labour Day"),
         (6, 23, "Luxembourg National Holiday"),
     )
+
+    def get_fixed_holidays(self, year):
+        days = super(Luxembourg, self).get_fixed_holidays(year)
+        if year > 2018:
+            days.append((date(year, 5, 9), "Europe Day"))
+
+        return days

--- a/calendra/europe/malta.py
+++ b/calendra/europe/malta.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MT')

--- a/calendra/europe/netherlands.py
+++ b/calendra/europe/netherlands.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('NL')

--- a/calendra/europe/norway.py
+++ b/calendra/europe/norway.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('NO')

--- a/calendra/europe/poland.py
+++ b/calendra/europe/poland.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PL')

--- a/calendra/europe/portugal.py
+++ b/calendra/europe/portugal.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('PT')

--- a/calendra/europe/romania.py
+++ b/calendra/europe/romania.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, OrthodoxMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('RO')

--- a/calendra/europe/russia.py
+++ b/calendra/europe/russia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('RU')
@@ -18,5 +18,5 @@ class Russia(WesternCalendar):
         (5, 1, "Labour Day"),
         (5, 9, "Victory Day"),
         (6, 12, "National Day"),
-        (11, 5, "Day of Unity"),
+        (11, 4, "Day of Unity"),
     )

--- a/calendra/europe/scotland/__init__.py
+++ b/calendra/europe/scotland/__init__.py
@@ -1,0 +1,500 @@
+"""
+Scotland specific module.
+
+The main source of information is:
+https://en.wikipedia.org/wiki/Public_and_bank_holidays_in_Scotland
+
+Note on "inheritance":
+
+* Carnoustie and Monifieth area is a subdivision of Angus
+* Lanark is part of South Lanarkshire
+
+FIXME:
+
+* Galashiels is part of the Scottish Borders
+* Hawick is part of the Scottish Borders
+* Kilmarnock is probably part of AyrShire (?)
+* Lanark is part of South Lanarkshire
+* Linlithgow... part of N/A
+* Lochaber... part of N/A
+* ...
+
+"""
+# Since Scotland territories have a lot of different variations, it has become
+# necessary to split this module and associated tests
+from datetime import date, timedelta
+import warnings
+from ...core import WesternCalendar, ChristianMixin
+from ...core import MON, THU, FRI
+from .mixins import (
+    SpringHolidayFirstMondayApril,
+    SpringHolidaySecondMondayApril,
+    SpringHolidayTuesdayAfterFirstMondayMay,
+    SpringHolidayLastMondayMay,
+    SpringHolidayFirstMondayJune,
+    VictoriaDayFourthMondayMay,
+    VictoriaDayLastMondayMay,
+    VictoriaDayFirstMondayJune,
+    FairHolidayLastMondayJune,
+    FairHolidayFirstMondayJuly,
+    FairHolidaySecondMondayJuly,
+    FairHolidayThirdMondayJuly,
+    FairHolidayLastMondayJuly,
+    FairHolidayFourthFridayJuly,
+    FairHolidayFirstMondayAugust,
+    LateSummer,
+    BattleStirlingBridge,
+    AutumnHolidayLastMondaySeptember,
+    AutumnHolidayFirstMondayOctober,
+    AutumnHolidaySecondMondayOctober,
+    AutumnHolidayThirdMondayOctober,
+    AyrGoldCup,
+)
+
+
+class Scotland(WesternCalendar, ChristianMixin):
+    "Scotland"
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 2, "New Year Holiday"),
+        (12, 26, "Boxing Day"),
+    )
+    include_spring_holiday = False
+    spring_holiday_label = "Spring Holiday"
+    include_fair_holiday = False
+    include_autumn_holiday = False
+    include_saint_andrew = False
+    include_victoria_day = False
+
+    def __init__(self, *args, **kwargs):
+        super(Scotland, self).__init__(*args, **kwargs)
+        warnings.warn(
+            """
+Please bear in mind that every Scotland (sub)calendar is highly experimental.
+
+It appeared throughout out searches that Scottish calendars have many
+exceptions and somes sources of information contradicts with each other.
+
+As a consequence, we advise our user to treat this Scotland submodule with
+as much care as possible.
+"""
+        )
+
+    def get_may_day(self, year):
+        """
+        May Day is the first Monday in May
+        """
+        return (
+            Scotland.get_nth_weekday_in_month(year, 5, MON),
+            "May Day"
+        )
+
+    def get_spring_holiday(self, year):
+        """
+        Return spring holiday date and label.
+
+        You need to implement it as soon as the flag `include_spring_holiday`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add spring holiday while "
+            "`get_spring_holiday` is not implemented.")
+
+    def get_fair_holiday(self, year):
+        """
+        Return fair holiday date and label.
+
+        You need to implement it as soon as the flag `include_fair_holiday`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add fair holiday while "
+            "`get_fair_holiday` is not implemented.")
+
+    def get_autumn_holiday(self, year):
+        """
+        Return autumn holiday date and label.
+
+        You need to implement it as soon as the flag `include_autumn_holiday`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add autumn holiday while "
+            "`get_autumn_holiday` is not implemented.")
+
+    def get_victoria_day(self, year):
+        """
+        Return Victoria day date and label.
+
+        You need to implement it as soon as the flag `include_victoria_day`
+        is True.
+        """
+        raise NotImplementedError(
+            "Tried to add autumn holiday while "
+            "`include_victoria_day` is not implemented.")
+
+    def get_variable_days(self, year):
+        days = super(Scotland, self).get_variable_days(year)
+        days.append(self.get_may_day(year))
+        if self.include_spring_holiday:
+            # This method is included in the spring_holiday mixins
+            days.append(self.get_spring_holiday(year))
+        if self.include_fair_holiday:
+            # This method is included in the fair_holiday mixins
+            days.append(self.get_fair_holiday(year))
+        if self.include_autumn_holiday:
+            # This method is included in the autumn_holiday mixins
+            days.append(self.get_autumn_holiday(year))
+        if self.include_victoria_day:
+            # This method is included in the victoria_day mixins
+            days.append(self.get_victoria_day(year))
+        return days
+
+    def get_fixed_holidays(self, year):
+        days = super(Scotland, self).get_fixed_holidays(year)
+        if self.include_saint_andrew:
+            days.append((date(year, 11, 30), "Saint Andrew's Day"))
+        return days
+
+
+class Aberdeen(
+        FairHolidaySecondMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Aberdeen"
+    include_good_friday = True
+
+
+class Angus(
+        SpringHolidaySecondMondayApril,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Angus"
+    include_saint_andrew = True
+
+
+class Arbroath(FairHolidayThirdMondayJuly, Scotland):
+    "Arbroath"
+
+
+class Ayr(SpringHolidayLastMondayMay, AyrGoldCup, Scotland):
+    "Ayr"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class CarnoustieMonifieth(
+        SpringHolidayFirstMondayApril,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Carnoustie & Monifieth"
+
+
+class Clydebank(
+        SpringHolidayTuesdayAfterFirstMondayMay,
+        Scotland):
+    "Clydebank"
+
+
+class DumfriesGalloway(Scotland):
+    "Dumfries & Galloway"
+    include_good_friday = True
+
+
+class Dundee(
+        SpringHolidayFirstMondayApril,
+        VictoriaDayLastMondayMay,
+        FairHolidayLastMondayJuly,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Dundee"
+
+
+class EastDunbartonshire(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "East Dunbartonshire"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Edinburgh(Scotland):
+    "Edinburgh"
+    include_good_friday = True
+    include_easter_monday = True
+    include_spring_holiday = True
+    include_victoria_day = True
+    include_autumn_holiday = True
+
+    def get_spring_holiday(self, year):
+        """
+        Return Spring Holiday for Edinburgh.
+
+        Set to the 3rd Monday of April, unless it falls on Easter Monday, then
+        it's shifted to previous week.
+        """
+        easter = self.get_easter_monday(year)
+        spring_holiday = self.get_nth_weekday_in_month(year, 4, MON, 3)
+        if easter == spring_holiday:
+            spring_holiday = self.get_nth_weekday_in_month(
+                year, 4, MON, 2)
+
+        return (spring_holiday, self.spring_holiday_label)
+
+    def get_victoria_day(self, year):
+        """
+        Return Victoria Day for Edinburgh.
+
+        Set to the Monday strictly before May 24th. It means that if May 24th
+        is a Monday, it's shifted to the week before.
+        """
+        may_24th = date(year, 5, 24)
+        # Since "MON(day) == 0", it's either the difference between MON and the
+        # current weekday (starting at 0), or 7 days before the May 24th
+        shift = may_24th.weekday() or 7
+        victoria_day = may_24th - timedelta(days=shift)
+        return (victoria_day, "Victoria Day")
+
+    def get_autumn_holiday(self, year):
+        """
+        Return Autumn Holiday for Edinburgh.
+
+        Set to the third Monday in September. Since it's the only region to
+        follow this rule, we won't have a Mixin associated to it.
+        """
+        return (
+            self.get_nth_weekday_in_month(year, 9, MON, 3),
+            "Autumn Holiday"
+        )
+
+
+class Elgin(
+        SpringHolidaySecondMondayApril,
+        FairHolidayLastMondayJune,
+        LateSummer,
+        AutumnHolidayThirdMondayOctober,
+        Scotland):
+    "Elgin"
+
+
+class Falkirk(FairHolidayFirstMondayJuly, BattleStirlingBridge, Scotland):
+    "Falkirk"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Fife(
+        VictoriaDayFirstMondayJune,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayThirdMondayOctober,
+        Scotland):
+    "Fife"
+    include_saint_andrew = True
+
+    def get_variable_days(self, year):
+        days = super(Fife, self).get_variable_days(year)
+        # Special computation rule, Fife has TWO spring holidays
+        # 1. First Monday in April
+        days.append((
+            self.get_nth_weekday_in_month(year, 4, MON),
+            "Spring Holiday"
+        ))
+        # 2. First Monday in June
+        days.append((
+            self.get_nth_weekday_in_month(year, 6, MON),
+            "Spring Holiday"
+        ))
+        return days
+
+
+class Galashiels(SpringHolidayFirstMondayJune, Scotland):
+    "Galashiels"
+
+    def get_variable_days(self, year):
+        days = super(Galashiels, self).get_variable_days(year)
+        # Adding Braw Lads Gathering, 1st Friday in July
+        days.append((
+            self.get_nth_weekday_in_month(year, 7, FRI),
+            "Braw Lads Gathering"
+        ))
+        return days
+
+
+class Glasgow(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Glasgow"
+    include_easter_monday = True
+
+
+class Hawick(Scotland):
+    "Hawick"
+
+    def get_variable_days(self, year):
+        days = super(Hawick, self).get_variable_days(year)
+        # Common Riding happens on the FRI after the first MON in June
+        first_monday = self.get_nth_weekday_in_month(year, 6, MON)
+        friday = first_monday + timedelta(days=4)
+        # And on the saturday. Adding this one, even if SAT is already a
+        # non-working day.
+        saturday = first_monday + timedelta(days=5)
+        days.append((friday, "Common Riding Day 1"))
+        days.append((saturday, "Common Riding Day 2"))
+        return days
+
+
+class Inverclyde(LateSummer, Scotland):
+    "Inverclyde"
+    include_good_friday = True
+    include_easter_monday = True
+
+    def get_variable_days(self, year):
+        days = super(Inverclyde, self).get_variable_days(year)
+        # Special computation rule, Inverclyde has TWO spring holidays
+        # 1. First Monday in April
+        days.append((
+            self.get_last_weekday_in_month(year, 4, MON),
+            "Spring Holiday"
+        ))
+        # 2. First Monday in June
+        days.append((
+            self.get_nth_weekday_in_month(year, 6, MON),
+            "Spring Holiday"
+        ))
+        return days
+
+
+class Inverness(
+        SpringHolidayFirstMondayApril,
+        FairHolidayFirstMondayJuly,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Inverness"
+
+    def get_variable_days(self, year):
+        days = super(Inverness, self).get_variable_days(year)
+        days.append((
+            self.get_nth_weekday_in_month(year, 2, MON),
+            "Winter Holiday (February)"
+        ))
+        days.append((
+            self.get_nth_weekday_in_month(year, 3, MON),
+            "Winter Holiday (March)"
+        ))
+        days.append((
+            self.get_nth_weekday_in_month(year, 11, MON),
+            "Samhain Holiday"
+        ))
+        return days
+
+
+class Kilmarnock(AyrGoldCup, Scotland):
+    "Kilmarnock"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Lanark(Scotland):
+    "Lanark"
+
+    def get_variable_days(self, year):
+        days = super(Lanark, self).get_variable_days(year)
+        # Lanimer is 2nd THU in June
+        days.append((
+            self.get_nth_weekday_in_month(year, 6, THU, 2),
+            "Lanimer Day"
+        ))
+        return days
+
+
+class Linlithgow(Scotland):
+    "Linlithgow"
+    def get_variable_days(self, year):
+        days = super(Linlithgow, self).get_variable_days(year)
+        # Linlithgow Marches is on TUE after the 2nd THU in June
+        second_thursday = self.get_nth_weekday_in_month(year, 6, THU, 2)
+        marches_day = second_thursday + timedelta(days=5)
+        days.append((
+            marches_day,
+            "Linlithgow Marches"
+        ))
+        return days
+
+
+class Lochaber(Scotland):
+    "Lochaber"
+    def get_variable_days(self, year):
+        days = super(Lochaber, self).get_variable_days(year)
+        # Winter holiday is on the last MON of march
+        days.append((
+            self.get_last_weekday_in_month(year, 3, MON),
+            "Winter holiday"
+        ))
+        return days
+
+
+class NorthLanarkshire(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "North Lanarkshire"
+    include_easter_monday = True
+
+
+class Paisley(
+        VictoriaDayLastMondayMay,
+        FairHolidayFirstMondayAugust,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "Paisley"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Perth(
+        SpringHolidayFirstMondayApril,
+        VictoriaDayFourthMondayMay,
+        BattleStirlingBridge,
+        AutumnHolidayFirstMondayOctober,
+        Scotland):
+    "Perth"
+
+
+class ScottishBorders(
+        SpringHolidayFirstMondayApril,
+        FairHolidayFourthFridayJuly,
+        AutumnHolidaySecondMondayOctober,
+        Scotland):
+    "Scottish Borders"
+    include_saint_andrew = True
+
+
+class SouthLanarkshire(
+        SpringHolidayLastMondayMay,
+        FairHolidayThirdMondayJuly,
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "South Lanarkshire"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class Stirling(
+        SpringHolidayTuesdayAfterFirstMondayMay,
+        BattleStirlingBridge,
+        Scotland):
+    "Stirling"
+    include_good_friday = True
+    include_easter_monday = True
+
+
+class WestDunbartonshire(
+        AutumnHolidayLastMondaySeptember,
+        Scotland):
+    "West Dunbartonshire"
+    include_good_friday = True
+    include_easter_monday = True

--- a/calendra/europe/scotland/mixins/__init__.py
+++ b/calendra/europe/scotland/mixins/__init__.py
@@ -1,0 +1,104 @@
+"""
+Scotland calendar mixins.
+
+There are so many of them that it became necessary to move them to a different
+module.
+"""
+from ....core import MON, FRI
+from datetime import timedelta
+
+from .spring_holiday import (
+    SpringHolidayFirstMondayApril,
+    SpringHolidaySecondMondayApril,
+    SpringHolidayTuesdayAfterFirstMondayMay,
+    SpringHolidayLastMondayMay,
+    SpringHolidayFirstMondayJune,
+)
+
+from .fair_holiday import (
+    FairHolidayLastMondayJune,
+    FairHolidayFirstMondayJuly,
+    FairHolidaySecondMondayJuly,
+    FairHolidayThirdMondayJuly,
+    FairHolidayLastMondayJuly,
+    FairHolidayFourthFridayJuly,
+    FairHolidayFirstMondayAugust,
+)
+
+from .victoria_day import (
+    VictoriaDayFourthMondayMay,
+    VictoriaDayLastMondayMay,
+    VictoriaDayFirstMondayJune,
+)
+
+from .autumn_holiday import (
+    AutumnHolidayLastMondaySeptember,
+    AutumnHolidayFirstMondayOctober,
+    AutumnHolidaySecondMondayOctober,
+    AutumnHolidayThirdMondayOctober,
+)
+
+
+class LateSummer(object):
+    def get_variable_days(self, year):
+        """
+        Add Late Summer holiday (First Monday of September)
+        """
+        days = super(LateSummer, self).get_variable_days(year)
+        days.append((
+            self.get_nth_weekday_in_month(year, 9, MON),
+            "Late Summer Holiday"
+        ))
+        return days
+
+
+class BattleStirlingBridge(object):
+    def get_variable_days(self, year):
+        """
+        Add Battle of Stirling Bridge holiday (Second Monday of September)
+        """
+        days = super(BattleStirlingBridge, self).get_variable_days(year)
+        days.append((
+            self.get_nth_weekday_in_month(year, 9, MON, 2),
+            "Battle of Stirling Bridge Holiday"
+        ))
+        return days
+
+
+class AyrGoldCup(object):
+    def get_variable_days(self, year):
+        days = super(AyrGoldCup, self).get_variable_days(year)
+        # Ayr Gold Cup
+        gold_cup_friday = self.get_nth_weekday_in_month(year, 9, FRI, 3)
+        days.append(
+            (gold_cup_friday, "Ayr Gold Cup Friday")
+        )
+        days.append(
+            (gold_cup_friday + timedelta(days=3), "Ayr Gold Cup Monday")
+        )
+        return days
+
+
+__all__ = [
+    'AyrGoldCup',
+    'SpringHolidayFirstMondayApril',
+    'SpringHolidaySecondMondayApril',
+    'SpringHolidayTuesdayAfterFirstMondayMay',
+    'SpringHolidayLastMondayMay',
+    'SpringHolidayFirstMondayJune',
+    'VictoriaDayFourthMondayMay',
+    'VictoriaDayLastMondayMay',
+    'VictoriaDayTuesdayAfterFirstMondayMay',
+    'VictoriaDayFirstMondayJune',
+    'FairHolidayLastMondayJune',
+    'FairHolidayFirstMondayJuly',
+    'FairHolidaySecondMondayJuly',
+    'FairHolidayThirdMondayJuly',
+    'FairHolidayLastMondayJuly',
+    'FairHolidayFourthFridayJuly',
+    'FairHolidayFirstMondayAugust',
+    'AutumnHolidayLastMondaySeptember',
+    'AutumnHolidayFirstMondayOctober',
+    'AutumnHolidaySecondMondayOctober',
+    'AutumnHolidayThirdMondayOctober',
+]

--- a/calendra/europe/scotland/mixins/autumn_holiday.py
+++ b/calendra/europe/scotland/mixins/autumn_holiday.py
@@ -1,0 +1,41 @@
+"""
+Autumn Holiday mixins
+"""
+from ....core import MON
+
+
+class AutumHoliday(object):
+    include_autumn_holiday = True
+    autumn_holiday_label = "Autumn Holiday"
+
+
+class AutumnHolidayLastMondaySeptember(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 9, MON),
+            self.autumn_holiday_label
+        )
+
+
+class AutumnHolidayFirstMondayOctober(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 10, MON),
+            self.autumn_holiday_label
+        )
+
+
+class AutumnHolidaySecondMondayOctober(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 10, MON, 2),
+            self.autumn_holiday_label
+        )
+
+
+class AutumnHolidayThirdMondayOctober(AutumHoliday):
+    def get_autumn_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 10, MON, 3),
+            self.autumn_holiday_label
+        )

--- a/calendra/europe/scotland/mixins/fair_holiday.py
+++ b/calendra/europe/scotland/mixins/fair_holiday.py
@@ -1,0 +1,72 @@
+"""
+Fair Holiday mixins
+"""
+from ....core import MON, FRI
+
+
+class FairHoliday(object):
+    include_fair_holiday = True
+    fair_holiday_label = "Fair Holiday"
+
+
+class FairHolidayLastMondayJune(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 6, MON),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayFirstMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, MON),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidaySecondMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, MON, 2),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayThirdMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, MON, 3),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayLastMondayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 7, MON),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayFourthFridayJuly(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 7, FRI, 4),
+            self.fair_holiday_label
+        )
+
+
+class FairHolidayFirstMondayAugust(FairHoliday):
+
+    def get_fair_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 8, MON),
+            self.fair_holiday_label
+        )

--- a/calendra/europe/scotland/mixins/spring_holiday.py
+++ b/calendra/europe/scotland/mixins/spring_holiday.py
@@ -1,0 +1,52 @@
+"""
+Spring Holiday mixins
+"""
+from datetime import timedelta
+
+from ....core import MON
+
+
+class SpringHoliday(object):
+    include_spring_holiday = True
+
+
+class SpringHolidayFirstMondayApril(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 4, MON),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidaySecondMondayApril(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 4, MON, 2),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidayTuesdayAfterFirstMondayMay(SpringHoliday):
+
+    def get_spring_holiday(self, year):
+        first_monday = self.get_nth_weekday_in_month(year, 5, MON)
+        return (
+            first_monday + timedelta(days=1),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidayLastMondayMay(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 5, MON),
+            self.spring_holiday_label
+        )
+
+
+class SpringHolidayFirstMondayJune(SpringHoliday):
+    def get_spring_holiday(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 6, MON),
+            self.spring_holiday_label
+        )

--- a/calendra/europe/scotland/mixins/victoria_day.py
+++ b/calendra/europe/scotland/mixins/victoria_day.py
@@ -1,0 +1,36 @@
+"""
+Victoria Day mixins
+"""
+from ....core import MON
+
+
+class VictoriaDayMixin(object):
+    include_victoria_day = True
+    victoria_day_label = "Victoria Day"
+
+
+class VictoriaDayFourthMondayMay(VictoriaDayMixin):
+
+    def get_victoria_day(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 5, MON, 4),
+            self.victoria_day_label
+        )
+
+
+class VictoriaDayLastMondayMay(VictoriaDayMixin):
+
+    def get_victoria_day(self, year):
+        return (
+            self.get_last_weekday_in_month(year, 5, MON),
+            self.victoria_day_label
+        )
+
+
+class VictoriaDayFirstMondayJune(VictoriaDayMixin):
+
+    def get_victoria_day(self, year):
+        return (
+            self.get_nth_weekday_in_month(year, 6, MON),
+            self.victoria_day_label
+        )

--- a/calendra/europe/slovakia.py
+++ b/calendra/europe/slovakia.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SK')

--- a/calendra/europe/slovenia.py
+++ b/calendra/europe/slovenia.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SI')

--- a/calendra/europe/spain.py
+++ b/calendra/europe/spain.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('ES')

--- a/calendra/europe/sweden.py
+++ b/calendra/europe/sweden.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from ..core import WesternCalendar, ChristianMixin
 from ..core import FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('SE')

--- a/calendra/europe/switzerland.py
+++ b/calendra/europe/switzerland.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 from datetime import date, timedelta
 from ..core import WesternCalendar, ChristianMixin
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('CH')

--- a/calendra/europe/turkey.py
+++ b/calendra/europe/turkey.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from datetime import timedelta
+from ..core import WesternCalendar, IslamicMixin
+from ..registry_tools import iso_register
+
+
+@iso_register('TR')
+class Turkey(WesternCalendar, IslamicMixin):
+    'Turkey'
+
+    shift_new_years_day = True
+
+    # Islamic Holidays
+    include_eid_al_fitr = True
+    length_eid_al_fitr = 3
+    include_eid_al_adha = True
+    length_eid_al_adha = 4
+
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (4, 23, "National Sovereignty and Children's Day"),
+        (5, 1, "Labor and Solidarity Day"),
+        (5, 19, "Commemoration of Atatürk, Youth and Sports Day"),
+        (7, 15, "Democracy and National Unity Day"),
+        (8, 30, "Victory Day"),
+        (9, 29, "Republic Day"),
+    )
+
+    def get_delta_islamic_holidays(self, year):
+        """
+        Turkey Islamic holidays are shifted by one day every year.
+        """
+        return timedelta(days=-1)

--- a/calendra/europe/united_kingdom.py
+++ b/calendra/europe/united_kingdom.py
@@ -18,13 +18,13 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
     include_boxing_day = True
     shift_new_years_day = True
     non_computable_holiday_dict = {
-        1973: [(date(1973, 11, 14), "Royal wedding")],
-        1977: [(date(1977, 6, 7), "Queen’s Silver Jubilee")],
-        1981: [(date(1981, 7, 29), "Royal wedding")],
-        1999: [(date(1999, 12, 31), "New Year's Eve")],
-        2002: [(date(2002, 6, 3), "Queen’s Golden Jubilee")],
-        2011: [(date(2011, 4, 29), "Royal Wedding")],
-        2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee")],
+        1973: [(date(1973, 11, 14), "Royal wedding"), ],
+        1977: [(date(1977, 6, 7), "Queen’s Silver Jubilee"), ],
+        1981: [(date(1981, 7, 29), "Royal wedding"), ],
+        1999: [(date(1999, 12, 31), "New Year's Eve"), ],
+        2002: [(date(2002, 6, 3), "Queen’s Golden Jubilee"), ],
+        2011: [(date(2011, 4, 29), "Royal Wedding"), ],
+        2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee"), ],
     }
 
     def get_early_may_bank_holiday(self, year):

--- a/calendra/europe/united_kingdom.py
+++ b/calendra/europe/united_kingdom.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from datetime import date
-from dateutil import relativedelta as rd
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import Holiday
@@ -54,7 +53,8 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         elif year == 2002:
             spring_bank_holiday = date(2002, 6, 4)
         else:
-            spring_bank_holiday = UnitedKingdom.get_last_weekday_in_month(year, 5, MON)
+            spring_bank_holiday = UnitedKingdom. \
+                get_last_weekday_in_month(year, 5, MON)
         return Holiday(
             spring_bank_holiday,
             "Spring Bank Holiday",

--- a/calendra/europe/united_kingdom.py
+++ b/calendra/europe/united_kingdom.py
@@ -36,7 +36,7 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         if year == 2020:
             return Holiday(
                 date(year, 5, 8),
-                "Early May Bank Holiday (VE day)",
+                "Early May bank holiday (VE day)",
                 indication="VE day",
             )
         else:

--- a/calendra/europe/united_kingdom.py
+++ b/calendra/europe/united_kingdom.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from datetime import date
-
 from dateutil import relativedelta as rd
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import Holiday
-from ..registry import iso_register
+from ..core import MON
+from ..registry_tools import iso_register
 
 
 @iso_register('GB')
@@ -18,26 +18,71 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
     include_easter_monday = True
     include_boxing_day = True
     shift_new_years_day = True
+    non_computable_holiday_dict = {
+        1973: [(date(1973, 11, 14), "Royal wedding")],
+        1977: [(date(1977, 6, 7), "Queen’s Silver Jubilee")],
+        1981: [(date(1981, 7, 29), "Royal wedding")],
+        1999: [(date(1999, 12, 31), "New Year's Eve")],
+        2002: [(date(2002, 6, 3), "Queen’s Golden Jubilee")],
+        2011: [(date(2011, 4, 29), "Royal Wedding")],
+        2012: [(date(2012, 6, 5), "Queen’s Diamond Jubilee")],
+    }
+
+    def get_early_may_bank_holiday(self, year):
+        """
+        Return Early May bank holiday
+        """
+        # Special case in 2020, for the 75th anniversary of the end of WWII.
+        if year == 2020:
+            return Holiday(
+                date(year, 5, 8),
+                "Early May Bank Holiday (VE day)",
+                indication="VE day",
+            )
+        else:
+            return Holiday(
+                UnitedKingdom.get_nth_weekday_in_month(year, 5, MON),
+                "Early May Bank Holiday",
+                indication="1st Monday in May",
+            )
+
+    def get_spring_bank_holiday(self, year):
+        if year == 2012:
+            spring_bank_holiday = date(2012, 6, 4)
+        elif year == 1977:
+            spring_bank_holiday = date(1977, 6, 6)
+        elif year == 2002:
+            spring_bank_holiday = date(2002, 6, 4)
+        else:
+            spring_bank_holiday = UnitedKingdom.get_last_weekday_in_month(year, 5, MON)
+        return Holiday(
+            spring_bank_holiday,
+            "Spring Bank Holiday",
+            indication="Last Monday in May"
+        )
+
+    def get_late_summer_bank_holiday(self, year):
+        return Holiday(
+            UnitedKingdom.get_last_weekday_in_month(year, 8, MON),
+            "Late Summer Bank Holiday",
+            indication="Last Monday in August",
+        )
+
+    def non_computable_holiday(self, year):
+        non_computable = self.non_computable_holiday_dict.get(year, None)
+        return non_computable
 
     def get_variable_days(self, year):
         days = super(UnitedKingdom, self).get_variable_days(year)
-        days += [
-            Holiday(
-                date(year, 5, 1) + rd.relativedelta(weekday=rd.MO(1)),
-                "Early May Bank Holiday",
-                indication="1st Monday in May",
-            ),
-            Holiday(
-                date(year, 5, 30) + rd.relativedelta(weekday=rd.MO(-1)),
-                "Spring Bank Holiday",
-                indication="Last Monday in May",
-            ),
-            Holiday(
-                date(year, 8, 31) + rd.relativedelta(weekday=rd.MO(-1)),
-                "Late Summer Bank Holiday",
-                indication="Last Monday in August",
-            ),
-        ]
+        days.append(self.get_early_may_bank_holiday(year))
+        days.append(self.get_spring_bank_holiday(year))
+        days.append(self.get_late_summer_bank_holiday(year))
+        # Boxing day & XMas shift
+        shifts = self.shift_christmas_boxing_days(year=year)
+        days.extend(shifts)
+        non_computable = self.non_computable_holiday(year)
+        if non_computable:
+            days.extend(non_computable)
         return days
 
 

--- a/calendra/europe/united_kingdom.py
+++ b/calendra/europe/united_kingdom.py
@@ -2,9 +2,10 @@
 from __future__ import unicode_literals
 from datetime import date
 
+from dateutil import relativedelta as rd
+
 from ..core import WesternCalendar, ChristianMixin
 from ..core import Holiday
-from ..core import MON
 from ..registry_tools import iso_register
 
 
@@ -31,38 +32,32 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         """
         Return Early May bank holiday
         """
+        day = date(year, 5, 1) + rd.relativedelta(weekday=rd.MO(1))
+        desc = "Early May Bank Holiday"
+        indication = "1st Monday in May"
+
         # Special case in 2020, for the 75th anniversary of the end of WWII.
         if year == 2020:
-            return Holiday(
-                date(year, 5, 8),
-                "Early May bank holiday (VE day)",
-                indication="VE day",
-            )
-        return Holiday(
-            UnitedKingdom.get_nth_weekday_in_month(year, 5, MON),
-            "Early May Bank Holiday",
-            indication="1st Monday in May",
-        )
+            day = date(year, 5, 8)
+            desc += " (VE day)"
+            indication = "VE day"
+        return Holiday(day, desc, indication=indication)
 
     def get_spring_bank_holiday(self, year):
-        if year == 2012:
-            spring_bank_holiday = date(2012, 6, 4)
-        elif year == 1977:
-            spring_bank_holiday = date(1977, 6, 6)
-        elif year == 2002:
-            spring_bank_holiday = date(2002, 6, 4)
-        else:
-            spring_bank_holiday = UnitedKingdom. \
-                get_last_weekday_in_month(year, 5, MON)
+        day = date(year, 5, 30) + rd.relativedelta(weekday=rd.MO(-1))
+        if year in (2012, 2002):
+            day = date(year, 6, 4)
+        if year in (1977,):
+            day = date(year, 6, 6)
         return Holiday(
-            spring_bank_holiday,
+            day,
             "Spring Bank Holiday",
-            indication="Last Monday in May"
-        )
+            indication="Last Monday in May",
+        ),
 
     def get_late_summer_bank_holiday(self, year):
         return Holiday(
-            UnitedKingdom.get_last_weekday_in_month(year, 8, MON),
+            date(year, 8, 31) + rd.relativedelta(weekday=rd.MO(-1)),
             "Late Summer Bank Holiday",
             indication="Last Monday in August",
         )
@@ -76,9 +71,6 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
         days.append(self.get_early_may_bank_holiday(year))
         days.append(self.get_spring_bank_holiday(year))
         days.append(self.get_late_summer_bank_holiday(year))
-        # Boxing day & XMas shift
-        shifts = self.shift_christmas_boxing_days(year=year)
-        days.extend(shifts)
         non_computable = self.non_computable_holiday(year)
         if non_computable:
             days.extend(non_computable)

--- a/calendra/europe/united_kingdom.py
+++ b/calendra/europe/united_kingdom.py
@@ -38,12 +38,11 @@ class UnitedKingdom(WesternCalendar, ChristianMixin):
                 "Early May bank holiday (VE day)",
                 indication="VE day",
             )
-        else:
-            return Holiday(
-                UnitedKingdom.get_nth_weekday_in_month(year, 5, MON),
-                "Early May Bank Holiday",
-                indication="1st Monday in May",
-            )
+        return Holiday(
+            UnitedKingdom.get_nth_weekday_in_month(year, 5, MON),
+            "Early May Bank Holiday",
+            indication="1st Monday in May",
+        )
 
     def get_spring_bank_holiday(self, year):
         if year == 2012:

--- a/calendra/oceania/__init__.py
+++ b/calendra/oceania/__init__.py
@@ -12,6 +12,7 @@ from .australia import (
     WesternAustralia
 )
 from .marshall_islands import MarshallIslands
+from .new_zealand import NewZealand
 
 
 __all__ = (
@@ -28,4 +29,5 @@ __all__ = (
     'WesternAustralia',
     # Other oceanian countries
     'MarshallIslands',
+    'NewZealand',
 )

--- a/calendra/oceania/australia.py
+++ b/calendra/oceania/australia.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import MON, TUE, SAT, SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('AU')
@@ -97,16 +97,27 @@ class AustralianCapitalTerritory(Australia):
     include_labour_day_october = True
     include_boxing_day = True
 
+    _family_community_label = "Family & Community Day"
+
     def get_family_community_day(self, year):
+        """
+        Return Family & Community Day.
+
+        see: https://en.wikipedia.org/wiki/Family_Day#Australia
+        """
         # Since this day is picked unsing the school year calendar, there's no
-        # mathematical way yet to provide it surely
+        # mathematical way yet to compute it.
+
+        # This public holiday was declared in 2007. [..]
+        # Per Holidays (Reconciliation Day) Amendment Bill 2017, 2017 is the
+        # last year that ACT will celebrate family and community day. It is
+        # being replaced by Reconciliaton day.
+        if year < 2007 or year > 2018:
+            # This would be interpreted as "this holiday must not be added"
+            return None
 
         # Family & Community Day was celebrated on the first Tuesday of
         # November in 2007, 2008 and 2009
-
-        # Per Holidays (Reconciliation Day) Amendment Bill 2017, 2017 is the
-        # last year that ACT will celebrate family and community day. It is
-        # being replaced by Reconciliaton day
         if year in (2007, 2008, 2009):
             day = AustralianCapitalTerritory.get_nth_weekday_in_month(
                 year, 11, TUE)
@@ -121,18 +132,28 @@ class AustralianCapitalTerritory(Australia):
             day = AustralianCapitalTerritory.get_nth_weekday_in_month(
                 year, 10, MON, 2)
         else:
+            # If for some reason the year is not correctly provided
+            # (not and int, or whatever)
             return None
-        return (day, "Family & Community Day")
+
+        return (day, self._family_community_label)
 
     def get_reconciliation_day(self, year):
-        if year >= 2018:
-            reconciliation_day = date(year, 5, 27)
-            if reconciliation_day.weekday() == MON:
-                return (reconciliation_day, "Reconciliation Day")
-            else:
-                shift = AustralianCapitalTerritory.get_first_weekday_after(
-                    reconciliation_day, MON)
-                return shift, "Reconciliation Day Shift"
+        """
+        Return Reconciliaton Day.
+
+        As of 2018, it replaces Family & Community Day.
+        """
+        if year < 2018:
+            return None
+
+        reconciliation_day = date(year, 5, 27)
+        if reconciliation_day.weekday() == MON:
+            return (reconciliation_day, "Reconciliation Day")
+        else:
+            shift = AustralianCapitalTerritory.get_first_weekday_after(
+                reconciliation_day, MON)
+            return shift, "Reconciliation Day Shift"
 
     def get_variable_days(self, year):
         days = super(AustralianCapitalTerritory, self).get_variable_days(year)

--- a/calendra/oceania/marshall_islands.py
+++ b/calendra/oceania/marshall_islands.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 from ..core import WesternCalendar, ChristianMixin
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('MH')

--- a/calendra/oceania/new_zealand.py
+++ b/calendra/oceania/new_zealand.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
-from datetime import date, timedelta
+from datetime import date
+
+from dateutil import relativedelta as rd
 
 from ..core import WesternCalendar, ChristianMixin
-from ..core import MON, SAT, SUN
+from ..core import Holiday
 from ..registry_tools import iso_register
+
+
+def _by_name(holidays):
+    return {day.name: day for day in holidays if hasattr(day, 'name')}
 
 
 @iso_register("NZ")
@@ -12,76 +18,35 @@ class NewZealand(WesternCalendar, ChristianMixin):
     include_good_friday = True
     include_easter_monday = True
     include_boxing_day = True
+    shift_new_years_day = True
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
-        (1, 2, "Day after New Year's Day"),
-        (2, 6, "Waitangi Day"),
-        (4, 25, "ANZAC Day")
+        Holiday(date(2000, 2, 6), "Waitangi Day"),
+        Holiday(date(2000, 4, 25), "ANZAC Day"),
     )
 
     def get_queens_birthday(self, year):
-        return (
-            NewZealand.get_nth_weekday_in_month(year, 6, MON, 1),
-            "Queen's Birthday"
+        return Holiday(
+            date(year, 6, 1) + rd.relativedelta(weekday=rd.MO(1)),
+            "Queen's Birthday",
+            indication="First Monday in June",
         )
 
     def get_labour_day(self, year):
-        return (
-            NewZealand.get_nth_weekday_in_month(year, 10, MON, 4),
-            "Labour Day"
+        return Holiday(
+            date(year, 10, 1) + rd.relativedelta(weekday=rd.MO(4)),
+            "Labour Day",
+            indication="Fourth Monday in October",
         )
 
     def get_variable_days(self, year):
         # usual variable days
         days = super(NewZealand, self).get_variable_days(year)
+        days.append(Holiday(
+            date(year, 1, 2),
+            "Day after New Year's Day",
+            observe_after=_by_name(days)["New year"],
+        ))
         days.append(self.get_queens_birthday(year))
         days.append(self.get_labour_day(year))
-
-        waitangi_day = date(year, 2, 6)
-        if waitangi_day.weekday() in self.get_weekend_days():
-            days.append((
-                self.find_following_working_day(waitangi_day),
-                "Waitangi Day Shift")
-            )
-
-        anzac_day = date(year, 4, 25)
-        if anzac_day.weekday() in self.get_weekend_days():
-            days.append((
-                self.find_following_working_day(anzac_day),
-                "ANZAC Day Shift")
-            )
-
-        christmas = date(year, 12, 25)
-        boxing_day = date(year, 12, 26)
-        if christmas.weekday() is SAT:
-            shift = self.find_following_working_day(christmas)
-            days.append((shift, "Christmas Shift"))
-        elif christmas.weekday() is SUN:
-            shift = self.find_following_working_day(christmas)
-            days.append((shift + timedelta(days=1), "Christmas Shift"))
-
-        if boxing_day.weekday() is SAT:
-            shift = self.find_following_working_day(boxing_day)
-            days.append((shift, "Boxing Day Shift"))
-        elif boxing_day.weekday() is SUN:
-            shift = self.find_following_working_day(boxing_day)
-            days.append((shift + timedelta(days=1), "Boxing Day Shift"))
-
-        new_year = date(year, 1, 1)
-        day_after_new_year = date(year, 1, 2)
-        if new_year.weekday() is SAT:
-            shift = self.find_following_working_day(new_year)
-            days.append((shift, "New Year Shift"))
-        elif new_year.weekday() is SUN:
-            shift = self.find_following_working_day(new_year)
-            days.append((shift + timedelta(days=1), "New Year Shift"))
-
-        if day_after_new_year.weekday() is SAT:
-            shift = self.find_following_working_day(day_after_new_year)
-            days.append((shift, "Day after New Year's Day Shift"))
-        elif day_after_new_year.weekday() is SUN:
-            shift = self.find_following_working_day(day_after_new_year)
-            days.append((shift + timedelta(days=1),
-                         "Day after New Year's Day Shift"))
-
         return days

--- a/calendra/oceania/new_zealand.py
+++ b/calendra/oceania/new_zealand.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from datetime import date, timedelta
+
+from ..core import WesternCalendar, ChristianMixin
+from ..core import MON, SAT, SUN
+from ..registry_tools import iso_register
+
+
+@iso_register("NZ")
+class NewZealand(WesternCalendar, ChristianMixin):
+    "New Zealand"
+    include_good_friday = True
+    include_easter_monday = True
+    include_boxing_day = True
+
+    FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
+        (1, 2, "Day after New Year's Day"),
+        (2, 6, "Waitangi Day"),
+        (4, 25, "ANZAC Day")
+    )
+
+    def get_queens_birthday(self, year):
+        return (
+            NewZealand.get_nth_weekday_in_month(year, 6, MON, 1),
+            "Queen's Birthday"
+        )
+
+    def get_labour_day(self, year):
+        return (
+            NewZealand.get_nth_weekday_in_month(year, 10, MON, 4),
+            "Labour Day"
+        )
+
+    def get_variable_days(self, year):
+        # usual variable days
+        days = super(NewZealand, self).get_variable_days(year)
+        days.append(self.get_queens_birthday(year))
+        days.append(self.get_labour_day(year))
+
+        waitangi_day = date(year, 2, 6)
+        if waitangi_day.weekday() in self.get_weekend_days():
+            days.append((
+                self.find_following_working_day(waitangi_day),
+                "Waitangi Day Shift")
+            )
+
+        anzac_day = date(year, 4, 25)
+        if anzac_day.weekday() in self.get_weekend_days():
+            days.append((
+                self.find_following_working_day(anzac_day),
+                "ANZAC Day Shift")
+            )
+
+        christmas = date(year, 12, 25)
+        boxing_day = date(year, 12, 26)
+        if christmas.weekday() is SAT:
+            shift = self.find_following_working_day(christmas)
+            days.append((shift, "Christmas Shift"))
+        elif christmas.weekday() is SUN:
+            shift = self.find_following_working_day(christmas)
+            days.append((shift + timedelta(days=1), "Christmas Shift"))
+
+        if boxing_day.weekday() is SAT:
+            shift = self.find_following_working_day(boxing_day)
+            days.append((shift, "Boxing Day Shift"))
+        elif boxing_day.weekday() is SUN:
+            shift = self.find_following_working_day(boxing_day)
+            days.append((shift + timedelta(days=1), "Boxing Day Shift"))
+
+        new_year = date(year, 1, 1)
+        day_after_new_year = date(year, 1, 2)
+        if new_year.weekday() is SAT:
+            shift = self.find_following_working_day(new_year)
+            days.append((shift, "New Year Shift"))
+        elif new_year.weekday() is SUN:
+            shift = self.find_following_working_day(new_year)
+            days.append((shift + timedelta(days=1), "New Year Shift"))
+
+        if day_after_new_year.weekday() is SAT:
+            shift = self.find_following_working_day(day_after_new_year)
+            days.append((shift, "Day after New Year's Day Shift"))
+        elif day_after_new_year.weekday() is SUN:
+            shift = self.find_following_working_day(day_after_new_year)
+            days.append((shift + timedelta(days=1),
+                         "Day after New Year's Day Shift"))
+
+        return days

--- a/calendra/registry_tools.py
+++ b/calendra/registry_tools.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import warnings
 from collections import OrderedDict
+from importlib import import_module
 
 
 class IsoRegistry(object):
@@ -13,8 +15,51 @@ class IsoRegistry(object):
     Two letter codes are favored for any subdivisions.
     """
 
-    def __init__(self):
+    STANDARD_MODULES = (
+        # Europe Countries
+        'europe',
+        # United States of America
+        'usa',
+        # American continent outside of USA
+        'america',
+        # African continent
+        'africa',
+        # Asia
+        'asia',
+        # Oceania
+        'oceania',
+    )
+
+    def __init__(self, load_standard_modules=False):
+        warnings.warn(
+            "The use of ``OrderedDict`` objects in the registry feature is "
+            "about to be deprecated, in favor of plain ``dict`` objects",
+            DeprecationWarning
+        )
         self.region_registry = OrderedDict()
+        if load_standard_modules:
+            for module_name in self.STANDARD_MODULES:
+                module = 'calendra.{}'.format(module_name)
+                all_classes = getattr(import_module(module), '__all__')
+                self.load_module_from_items(module, all_classes)
+
+    def register(self, iso_code, cls):
+        """
+        Store the ``cls`` in the region_registry.
+        """
+        self.region_registry[iso_code] = cls
+
+    def load_module_from_items(self, module_name, items):
+        """
+        Load all registered classes in the registry
+        """
+        for item in items:
+            cls = getattr(import_module(module_name), item)
+            iso_stuff = getattr(cls, '__iso_code', None)
+            if iso_stuff:
+                iso_code, class_name = iso_stuff
+                if iso_code and cls.__name__ == class_name:
+                    self.register(iso_code, cls)
 
     def _code_elements(self, iso_code):
         code_elements = iso_code.split('-')
@@ -23,12 +68,9 @@ class IsoRegistry(object):
             is_subregion = True
         return code_elements, is_subregion
 
-    def register(self, iso_code, cls):
-        self.region_registry[iso_code] = cls
-
     def get_calendar_class(self, iso_code):
         """
-        Retrieves calendar class associated with given ``iso_code``.
+        Retrieve calendar class associated with given ``iso_code``.
 
         If calendar of subdivision is not registered
         (for subdivision like ISO codes, e.g. GB-ENG)
@@ -106,6 +148,7 @@ def iso_register(iso_code):
 
     >>> calendar = registry.get_calendar_class('MC-MR')
     """
+
     def wrapper(cls):
         registry.register(iso_code, cls)
         return cls

--- a/calendra/tests/__init__.py
+++ b/calendra/tests/__init__.py
@@ -9,6 +9,7 @@ class GenericCalendarTest(TestCase):
     cal_class = Calendar
 
     def setUp(self):
-        warnings.simplefilter("ignore")
+        super(GenericCalendarTest, self).setUp()
+        warnings.simplefilter('ignore')
         self.year = date.today().year
         self.cal = self.cal_class()

--- a/calendra/tests/test_africa.py
+++ b/calendra/tests/test_africa.py
@@ -466,6 +466,14 @@ class SouthAfricaTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2016)
         self.assertIn(date(2016, 8, 3), holidays)
 
+    def test_special_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 5, 8), holidays)  # 2019 National Elections
+
+        # Only in 2019
+        holidays = self.cal.holidays_set(2017)
+        self.assertNotIn(date(2017, 5, 8), holidays)
+
 
 class MadagascarTest(GenericCalendarTest):
     cal_class = Madagascar

--- a/calendra/tests/test_america.py
+++ b/calendra/tests/test_america.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from datetime import date
 from . import GenericCalendarTest
-from ..america import Colombia
-from ..america import Mexico, Chile, Panama
+from ..america import Colombia, Barbados
+from ..america import Mexico, Chile, Panama, Paraguay
 
 
 class ChileTest(GenericCalendarTest):
@@ -116,6 +116,93 @@ class PanamaTest(GenericCalendarTest):
         self.assertIn(date(2013, 11, 5), holidays)  # colon day
         # Shout in Villa de los Santos
         self.assertIn(date(2013, 11, 10), holidays)
-        self.assertIn(date(2013, 12, 2), holidays)  # Independence from spain
+        self.assertIn(date(2013, 11, 28), holidays)  # Independence from spain
         self.assertIn(date(2013, 12, 8), holidays)  # mother day
         self.assertIn(date(2013, 12, 25), holidays)  # XMas
+
+
+class ParaguayTest(GenericCalendarTest):
+    cal_class = Paraguay
+
+    def test_holidays_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 1), holidays)
+        self.assertIn(date(2019, 3, 1), holidays)  # Heroes day
+        self.assertIn(date(2019, 4, 18), holidays)  # Maundy thursday
+        self.assertIn(date(2019, 4, 19), holidays)  # Good friday
+        self.assertIn(date(2019, 5, 1), holidays)  # Labour day
+        self.assertIn(date(2019, 5, 14), holidays)  # Independance day
+        self.assertIn(date(2019, 6, 12), holidays)  # Chaco Armistice Day
+        self.assertIn(date(2019, 8, 15), holidays)  # Founding of Asunción
+        self.assertIn(date(2019, 9, 29), holidays)  # Boqueron Battle Victory
+        self.assertIn(date(2019, 12, 8), holidays)  # Virgin of Caacupe
+        self.assertIn(date(2019, 12, 25), holidays)  # XMas
+
+    def test_holidays_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        # In 2017, Heroes day has been moved to February 27th
+        self.assertNotIn(date(2017, 3, 1), holidays)
+        self.assertIn(date(2017, 2, 27), holidays)
+        # Fundation of Asunción day: moved to August 14 for 2017
+        self.assertNotIn(date(2017, 8, 15), holidays)
+        self.assertIn(date(2017, 8, 14), holidays)
+        # Boqueron Battle Victory Day: moved to October 2nd for 2017
+        self.assertNotIn(date(2017, 9, 29), holidays)
+        self.assertIn(date(2017, 10, 2), holidays)
+
+
+class BarbadosTest(GenericCalendarTest):
+    cal_class = Barbados
+
+    def test_holidays_2009(self):
+        holidays = self.cal.holidays_set(2009)
+        self.assertIn(date(2009, 1, 1), holidays)
+        self.assertIn(date(2009, 1, 21), holidays)  # Errol Barrow Day
+        self.assertIn(date(2009, 4, 10), holidays)  # Good Friday
+        self.assertIn(date(2009, 4, 12), holidays)  # Easter Sunday
+        self.assertIn(date(2009, 4, 13), holidays)  # Easter Monday
+        self.assertIn(date(2009, 4, 28), holidays)  # National Heroes Day
+        self.assertIn(date(2009, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2009, 6, 1), holidays)  # Whit Monday
+        self.assertIn(date(2009, 8, 1), holidays)  # Emancipation Day
+        self.assertIn(date(2009, 8, 3), holidays)  # Kabooment Day
+        self.assertIn(date(2009, 11, 30), holidays)  # Independant Day
+        self.assertIn(date(2009, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2009, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)
+        self.assertIn(date(2018, 1, 21), holidays)  # Errol Barrow Day
+        self.assertIn(date(2018, 1, 22), holidays)  # Errol Barrow Day (shift)
+        self.assertIn(date(2018, 3, 30), holidays)  # Good Friday
+        self.assertIn(date(2018, 4, 1), holidays)  # Easter Sunday
+        self.assertIn(date(2018, 4, 2), holidays)  # Easter Monday
+        self.assertIn(date(2018, 4, 28), holidays)  # National Heroes Day
+        self.assertIn(date(2018, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2018, 5, 21), holidays)  # Whit Monday
+        self.assertIn(date(2018, 8, 1), holidays)  # Emancipation Day
+        self.assertIn(date(2018, 8, 6), holidays)  # Kabooment Day
+        self.assertIn(date(2018, 11, 30), holidays)  # Independant Day
+        self.assertIn(date(2018, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2018, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 1), holidays)
+        self.assertIn(date(2019, 1, 21), holidays)  # Errol Barrow Day
+        self.assertIn(date(2019, 4, 19), holidays)  # Good Friday
+        self.assertIn(date(2019, 4, 21), holidays)  # Easter Sunday
+        self.assertIn(date(2019, 4, 22), holidays)  # Easter Monday
+
+        # National Heroes Day & shift
+        self.assertIn(date(2019, 4, 28), holidays)
+        self.assertIn(date(2019, 4, 29), holidays)  # shft'd
+
+        self.assertIn(date(2019, 5, 1), holidays)  # Labour Day
+        self.assertIn(date(2019, 6, 10), holidays)  # Whit Monday
+        self.assertIn(date(2019, 8, 1), holidays)  # Emancipation Day
+        self.assertIn(date(2019, 8, 5), holidays)  # Kabooment Day
+        self.assertIn(date(2019, 11, 30), holidays)  # Independant Day
+        self.assertIn(date(2019, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2019, 12, 26), holidays)  # Boxing Day

--- a/calendra/tests/test_asia.py
+++ b/calendra/tests/test_asia.py
@@ -2,8 +2,39 @@ from datetime import date
 
 from . import GenericCalendarTest
 
-from ..asia import HongKong, Japan, Qatar, Singapore
-from ..asia import SouthKorea, Taiwan, Malaysia
+from ..asia import HongKong, Japan, JapanBank, Qatar, Singapore
+from ..asia import SouthKorea, Taiwan, Malaysia, China, Israel
+
+
+class ChinaTest(GenericCalendarTest):
+
+    cal_class = China
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)    # New year
+        self.assertIn(date(2018, 2, 15), holidays)   # Spring Festival
+        self.assertIn(date(2018, 2, 21), holidays)   # Spring Festival
+        self.assertIn(date(2018, 10, 1), holidays)   # National Day
+        self.assertIn(date(2018, 10, 7), holidays)   # National Day
+
+        # Variable days
+        self.assertIn(date(2018, 4, 5), holidays)    # Ching Ming Festival
+        self.assertIn(date(2018, 4, 7), holidays)    # Ching Ming Festival
+        self.assertIn(date(2018, 4, 29), holidays)   # Labour Day Holiday
+        self.assertIn(date(2018, 5, 1), holidays)    # Labour Day Holiday
+        self.assertIn(date(2018, 6, 18), holidays)   # Dragon Boat Festival
+        self.assertIn(date(2018, 9, 24), holidays)   # Mid-Autumn Festival
+        self.assertIn(date(2018, 12, 30), holidays)  # New year
+        self.assertIn(date(2018, 12, 31), holidays)  # New year
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertNotIn(date(2019, 4, 28), holidays)  # Labour Day Shift
+        self.assertIn(date(2019, 5, 1), holidays)  # Labour Day Holiday
+        self.assertIn(date(2019, 5, 2), holidays)  # Labour Day Holiday
+        self.assertIn(date(2019, 5, 3), holidays)  # Labour Day Holiday
+        self.assertNotIn(date(2019, 5, 5), holidays)  # Labour Day Shift
 
 
 class HongKongTest(GenericCalendarTest):
@@ -149,6 +180,45 @@ class JapanTest(GenericCalendarTest):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 8, 11), holidays)   # Mountain Day
 
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 14), holidays)  # Coming of Age Day
+        self.assertIn(date(2019, 5, 1), holidays)  # Coronation Day
+        self.assertIn(date(2019, 5, 6), holidays)  # Children's Day
+        self.assertIn(date(2019, 8, 12), holidays)  # Mountain Day Observed
+        self.assertIn(date(2019, 11, 4), holidays)  # Culture Day Observed
+
+    def test_year_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 7, 23), holidays)  # Marine Day
+        self.assertIn(date(2020, 7, 24), holidays)  # Sports Day
+        self.assertIn(date(2020, 8, 10), holidays)  # Mountain Day adjustment
+        self.assertNotIn(date(2020, 8, 11), holidays)  # Mountain Day
+        self.assertNotIn(date(2020, 12, 31), holidays)  # New Year's Bank Day
+
+
+class JapanBankTest(GenericCalendarTest):
+    cal_class = JapanBank
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 2), holidays)  # New Year's Bank Day
+        self.assertIn(date(2019, 1, 3), holidays)  # New Year's Bank Day
+        self.assertIn(date(2019, 1, 14), holidays)  # Coming of Age Day
+        self.assertIn(date(2019, 5, 3), holidays)  # Constitution Memorial Day
+        self.assertIn(date(2019, 11, 4), holidays)  # Culture Day Observed
+        self.assertIn(date(2019, 12, 31), holidays)  # New Year's Bank Day
+
+    def test_year_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 1, 2), holidays)  # New Year's Bank Day
+        self.assertIn(date(2020, 1, 3), holidays)  # New Year's Bank Day
+        self.assertIn(date(2020, 12, 31), holidays)  # New Year's Bank Day
+        self.assertIn(date(2020, 8, 10), holidays)  # Mountain Day adjustment
+        self.assertNotIn(date(2020, 8, 11), holidays)  # Mountain Day
+        self.assertIn(date(2020, 7, 23), holidays)  # Marine Day
+        self.assertIn(date(2020, 7, 24), holidays)  # Sports Day
+
 
 class MalaysiaTest(GenericCalendarTest):
     cal_class = Malaysia
@@ -192,6 +262,21 @@ class MalaysiaTest(GenericCalendarTest):
         self.assertIn(date(2017, 6, 12), holidays)
         holidays = self.cal.holidays_set(2018)
         self.assertIn(date(2018, 6, 1), holidays)
+
+    def test_fix_deepavali_2018(self):
+        holidays = self.cal.holidays(2018)
+        holidays = dict(holidays)
+        deepavali = date(2018, 11, 6)
+        self.assertIn(deepavali, holidays)
+        self.assertEqual(holidays[deepavali], "Deepavali")
+
+    def test_msia_thaipusam(self):
+        years = self.cal.MSIA_THAIPUSAM.keys()
+        # we only have them for years 2010-2020
+        self.assertEqual(
+            set(years),
+            set(range(2010, 2021))
+        )
 
 
 class QatarTest(GenericCalendarTest):
@@ -331,3 +416,74 @@ class TaiwanTest(GenericCalendarTest):
         self.assertIn(date(2012, 4, 4), self.cal.holidays_set(2012))
         self.assertIn(date(2013, 4, 4), self.cal.holidays_set(2013))
         self.assertIn(date(2014, 4, 4), self.cal.holidays_set(2014))
+
+
+class IsraelTest(GenericCalendarTest):
+
+    cal_class = Israel
+
+    def test_holidays_2017(self):
+        holidays = self.cal.holidays_set(2017)
+
+        self.assertIn(date(2017, 4, 11), holidays)  # Passover (Pesach)
+        self.assertIn(date(2017, 4, 17), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2017, 5, 2), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was early in 2017
+        self.assertIn(date(2017, 5, 31), holidays)  # Shavuot
+        self.assertIn(
+            date(2017, 9, 21), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2017, 9, 22), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2017, 9, 30), holidays
+        )  # Yom Kippur (already a Saturday - Shabbat, weekend day)
+        self.assertIn(date(2017, 10, 5), holidays)  # Sukkot
+        self.assertIn(date(2017, 10, 12), holidays)  # Sukkot
+
+    def test_holidays_2018(self):
+        holidays = self.cal.holidays_set(2018)
+
+        self.assertIn(date(2018, 3, 31), holidays)  # Passover (Pesach)
+        self.assertIn(date(2018, 4, 6), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2018, 4, 19), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was delayed in 2018
+        self.assertIn(date(2018, 5, 20), holidays)  # Shavuot
+        self.assertIn(
+            date(2018, 9, 10), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2018, 9, 11), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(date(2018, 9, 19), holidays)  # Yom Kippur
+        self.assertIn(date(2018, 9, 24), holidays)  # Sukkot
+        self.assertIn(date(2018, 9, 30), holidays)  # Sukkot
+
+    def test_holidays_2019(self):
+        holidays = self.cal.holidays_set(2019)
+
+        self.assertIn(date(2019, 4, 20), holidays)  # Passover (Pesach)
+        self.assertIn(date(2019, 4, 26), holidays)  # Passover (Pesach)
+        self.assertIn(
+            date(2019, 5, 9), holidays
+        )  # Independence Day (Yom Ha-Atzmaut), was delayed in 2019
+        self.assertIn(date(2019, 6, 9), holidays)  # Shavuot
+        self.assertIn(
+            date(2019, 9, 30), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2019, 10, 1), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(
+            date(2019, 10, 2), holidays
+        )  # Jewish New Year (Rosh Ha-Shana)
+        self.assertIn(date(2019, 10, 9), holidays)  # Yom Kippur
+        self.assertIn(date(2019, 10, 14), holidays)  # Sukkot
+        self.assertIn(date(2019, 10, 20), holidays)  # Sukkot
+
+        # Leap year Purim
+        self.assertIn(date(2019, 3, 21), holidays)  # purim
+        self.assertIn(date(2019, 3, 22), holidays)  # shushan purim

--- a/calendra/tests/test_europe.py
+++ b/calendra/tests/test_europe.py
@@ -6,6 +6,7 @@ from ..tests import GenericCalendarTest
 from ..europe import Austria
 from ..europe import Bulgaria
 from ..europe import Belgium
+from ..europe import CaymanIslands
 from ..europe import Croatia
 from ..europe import Cyprus
 from ..europe import CzechRepublic
@@ -77,6 +78,125 @@ class BulgariaTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 26), holidays)   # Christmas 2
         # Non-attendance day for schools, otherwise a working day.
         self.assertNotIn(date(2016, 11, 1), holidays)   # National Awakening
+
+
+class CaymanIslandsTest(GenericCalendarTest):
+    cal_class = CaymanIslands
+
+    def test_holidays_2013(self):
+        holidays = self.cal.holidays_set(2013)
+        self.assertIn(date(2013, 1, 1), holidays)
+        self.assertIn(date(2013, 1, 28), holidays)  # National Heroes Day
+        self.assertIn(date(2013, 2, 13), holidays)   # Ash Wednesday
+        self.assertIn(date(2013, 3, 29), holidays)  # good friday
+        self.assertIn(date(2013, 4, 1), holidays)  # easter monday
+        self.assertIn(date(2013, 5, 20), holidays)  # Discovery Day
+        self.assertIn(date(2013, 6, 17), holidays)  # Queen's Birthday
+        self.assertIn(date(2013, 7, 1), holidays)   # Constitution Day
+        self.assertIn(date(2013, 11, 11), holidays)  # Remembrance Day
+        self.assertIn(date(2013, 12, 25), holidays)  # XMas
+        self.assertIn(date(2013, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2014(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 1, 1), holidays)
+        self.assertIn(date(2014, 1, 27), holidays)  # National Heroes Day
+        self.assertIn(date(2014, 3, 5), holidays)   # Ash Wednesday
+        self.assertIn(date(2014, 4, 18), holidays)  # good friday
+        self.assertIn(date(2014, 4, 21), holidays)  # easter monday
+        self.assertIn(date(2014, 5, 19), holidays)  # Discovery Day
+        self.assertIn(date(2014, 6, 16), holidays)  # Queen's Birthday
+        self.assertIn(date(2014, 7, 7), holidays)   # Constitution Day
+        self.assertIn(date(2014, 11, 10), holidays)  # Remembrance Day
+        self.assertIn(date(2014, 12, 25), holidays)  # XMas
+        self.assertIn(date(2014, 12, 26), holidays)  # Boxing Day (on week-end)
+
+    def test_holidays_2015(self):
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 1, 1), holidays)
+        self.assertIn(date(2015, 1, 26), holidays)  # National Heroes Day
+        self.assertIn(date(2015, 2, 18), holidays)   # Ash Wednesday
+        self.assertIn(date(2015, 4, 3), holidays)  # good friday
+        self.assertIn(date(2015, 4, 6), holidays)  # easter monday
+        self.assertIn(date(2015, 5, 18), holidays)  # Discovery Day
+        self.assertIn(date(2015, 6, 15), holidays)  # Queen's Birthday
+        self.assertIn(date(2015, 7, 6), holidays)   # Constitution Day
+        self.assertIn(date(2015, 11, 9), holidays)  # Remembrance Day
+        self.assertIn(date(2015, 12, 25), holidays)  # XMas
+        self.assertIn(date(2015, 12, 26), holidays)  # Boxing Day (on week-end)
+        self.assertIn(date(2015, 12, 28), holidays)  # Boxing Day observed
+
+    def test_holidays_2016(self):
+        holidays = self.cal.holidays_set(2016)
+        self.assertIn(date(2016, 1, 1), holidays)
+        self.assertIn(date(2016, 1, 25), holidays)  # National Heroes Day
+        self.assertIn(date(2016, 2, 10), holidays)   # Ash Wednesday
+        self.assertIn(date(2016, 3, 25), holidays)  # good friday
+        self.assertIn(date(2016, 3, 28), holidays)  # easter monday
+        self.assertIn(date(2016, 5, 16), holidays)  # Discovery Day
+        self.assertIn(date(2016, 6, 13), holidays)  # Queen's Birthday
+        self.assertIn(date(2016, 7, 4), holidays)   # Constitution Day
+        self.assertIn(date(2016, 11, 14), holidays)  # Remembrance Day
+        self.assertIn(date(2016, 12, 26), holidays)  # XMas (in lieu)
+        self.assertIn(date(2016, 12, 27), holidays)  # Boxing Day (in lieu)
+
+    def test_holidays_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 1, 1), holidays)
+        self.assertIn(date(2017, 1, 2), holidays)  # New Year boxing
+        self.assertIn(date(2017, 1, 23), holidays)  # National Heroes Day
+        self.assertIn(date(2017, 3, 1), holidays)   # Ash Wednesday
+        self.assertIn(date(2017, 4, 14), holidays)  # good friday
+        self.assertIn(date(2017, 4, 17), holidays)  # easter monday
+        self.assertIn(date(2017, 5, 15), holidays)  # Discovery Day
+        self.assertIn(date(2017, 5, 24), holidays)  # Election Day
+        self.assertIn(date(2017, 6, 19), holidays)  # Queen's Birthday
+        self.assertIn(date(2017, 7, 3), holidays)   # Constitution Day
+        self.assertIn(date(2017, 11, 13), holidays)  # Remembrance Day
+        self.assertIn(date(2017, 12, 25), holidays)  # XMas
+        self.assertIn(date(2017, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)
+        self.assertIn(date(2018, 1, 22), holidays)  # National Heroes Day
+        self.assertIn(date(2018, 2, 14), holidays)   # Ash Wednesday
+        self.assertIn(date(2018, 3, 30), holidays)  # good friday
+        self.assertIn(date(2018, 4, 2), holidays)  # easter monday
+        self.assertIn(date(2018, 5, 21), holidays)  # Discovery Day
+        self.assertIn(date(2018, 6, 11), holidays)  # Queen's Birthday
+        self.assertIn(date(2018, 7, 2), holidays)   # Constitution Day
+        self.assertIn(date(2018, 11, 12), holidays)  # Remembrance Day
+        self.assertIn(date(2018, 12, 25), holidays)  # XMas
+        self.assertIn(date(2018, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 1), holidays)
+        self.assertIn(date(2019, 1, 28), holidays)  # National Heroes Day
+        self.assertIn(date(2019, 3, 6), holidays)   # Ash Wednesday
+        self.assertIn(date(2019, 4, 19), holidays)  # good friday
+        self.assertIn(date(2019, 4, 22), holidays)  # easter monday
+        self.assertIn(date(2019, 5, 20), holidays)  # Discovery Day
+        self.assertIn(date(2019, 6, 10), holidays)  # Queen's Birthday
+        self.assertIn(date(2019, 7, 1), holidays)   # Constitution Day
+        self.assertIn(date(2019, 11, 11), holidays)  # Remembrance Day
+        self.assertIn(date(2019, 12, 25), holidays)  # XMas
+        self.assertIn(date(2019, 12, 26), holidays)  # Boxing Day
+
+    def test_holidays_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 1, 1), holidays)
+        self.assertIn(date(2020, 1, 27), holidays)  # National Heroes Day
+        self.assertIn(date(2020, 2, 26), holidays)   # Ash Wednesday
+        self.assertIn(date(2020, 4, 10), holidays)  # good friday
+        self.assertIn(date(2020, 4, 13), holidays)  # easter monday
+        self.assertIn(date(2020, 5, 18), holidays)  # Discovery Day
+        self.assertIn(date(2020, 6, 15), holidays)  # Queen's Birthday
+        self.assertIn(date(2020, 7, 6), holidays)   # Constitution Day
+        self.assertIn(date(2020, 11, 9), holidays)  # Remembrance Day
+        self.assertIn(date(2020, 12, 25), holidays)  # XMas
+        self.assertIn(date(2020, 12, 26), holidays)  # Boxing Day
 
 
 class CroatiaTest(GenericCalendarTest):
@@ -155,7 +275,6 @@ class DenmarkTest(GenericCalendarTest):
     def test_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 1, 1), holidays)    # nytaarsdag
-        self.assertIn(date(2015, 3, 29), holidays)   # palmesoendag
         self.assertIn(date(2015, 4, 2), holidays)    # skaertaarsdag
         self.assertIn(date(2015, 4, 3), holidays)    # langfredag
         self.assertIn(date(2015, 4, 5), holidays)    # paaskedag
@@ -164,11 +283,8 @@ class DenmarkTest(GenericCalendarTest):
         self.assertIn(date(2015, 5, 14), holidays)   # kristi himmelfart
         self.assertIn(date(2015, 5, 24), holidays)   # pinsedag
         self.assertIn(date(2015, 5, 25), holidays)   # 2. pinsedag
-        self.assertIn(date(2015, 6, 5), holidays)    # grundlovsdag
-        self.assertIn(date(2015, 12, 24), holidays)  # juleaftensdag
         self.assertIn(date(2015, 12, 25), holidays)  # juledag
         self.assertIn(date(2015, 12, 26), holidays)  # 2. juledag
-        self.assertIn(date(2015, 12, 31), holidays)  # nytaarsaften
 
 
 class SlovakiaTest(GenericCalendarTest):
@@ -633,6 +749,13 @@ class LuxembourgTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 25), holidays)  # Christmas
         self.assertIn(date(2016, 12, 26), holidays)  # St. Stephen´s Day
 
+        self.assertNotIn(date(2016, 5, 9), holidays)  # Europe Day (>=2019)
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+
+        self.assertIn(date(2019, 5, 9), holidays)   # Europe Day (>=2019)
+
 
 class NetherlandsTest(GenericCalendarTest):
 
@@ -704,11 +827,59 @@ class Russia(GenericCalendarTest):
         self.assertIn(date(2018, 5, 1), holidays)  # Labour Day
         self.assertIn(date(2018, 5, 9), holidays)  # Victory Day
         self.assertIn(date(2018, 6, 12), holidays)  # National Day
-        self.assertIn(date(2018, 11, 5), holidays)  # Day of Unity
+        self.assertIn(date(2018, 11, 4), holidays)  # Day of Unity
 
 
 class UnitedKingdomTest(GenericCalendarTest):
     cal_class = UnitedKingdom
+
+    def test_year_1973(self):
+        holidays = self.cal.holidays_set(1973)
+        self.assertIn(date(1973, 11, 14), holidays)  # royal wedding
+
+    def test_year_1977(self):
+        holidays = self.cal.holidays_set(1977)
+        self.assertIn(date(1977, 6, 6), holidays)  # Early May Bank Holiday
+        self.assertIn(date(1977, 6, 7), holidays)  # queen's silver jubilee
+
+    def test_year_1981(self):
+        holidays = self.cal.holidays_set(1981)
+        self.assertIn(date(1981, 7, 29), holidays)  # royal wedding
+
+    def test_year_1999(self):
+        holidays = self.cal.holidays_set(1999)
+        self.assertIn(date(1999, 12, 31), holidays)  # new year's eve
+
+    def test_year_2002(self):
+        holidays = self.cal.holidays_set(2002)
+        self.assertIn(date(2002, 1, 1), holidays)  # new year day
+        self.assertIn(date(2002, 3, 29), holidays)  # good friday
+        self.assertIn(date(2002, 3, 31), holidays)  # easter sunday
+        self.assertIn(date(2002, 4, 1), holidays)  # easter monday
+        self.assertIn(date(2002, 5, 6), holidays)  # Early May Bank Holiday
+        self.assertIn(date(2002, 6, 3), holidays)  # queen's golden jubilee
+        self.assertIn(date(2002, 6, 4), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2002, 8, 26), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2002, 12, 25), holidays)  # Christmas
+        self.assertIn(date(2002, 12, 26), holidays)  # Boxing Day
+
+    def test_year_2011(self):
+        holidays = self.cal.holidays_set(2011)
+        self.assertIn(date(2011, 4, 29), holidays)  # royal wedding
+
+    def test_year_2012(self):
+        holidays = self.cal.holidays_set(2012)
+        self.assertIn(date(2012, 1, 1), holidays)  # new year day
+        self.assertIn(date(2012, 1, 2), holidays)  # new year shift
+        self.assertIn(date(2012, 4, 6), holidays)  # good friday
+        self.assertIn(date(2012, 4, 8), holidays)  # easter sunday
+        self.assertIn(date(2012, 4, 9), holidays)  # easter monday
+        self.assertIn(date(2012, 5, 7), holidays)  # Early May Bank Holiday
+        self.assertIn(date(2012, 6, 4), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2012, 6, 5), holidays)  # queen's diamond jubilee
+        self.assertIn(date(2012, 8, 27), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2012, 12, 25), holidays)  # Christmas
+        self.assertIn(date(2012, 12, 26), holidays)  # Boxing Day
 
     def test_year_2013(self):
         holidays = self.cal.holidays_set(2013)
@@ -751,6 +922,30 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2016, 12, 25), holidays)  # Christmas - Sunday
         self.assertIn(date(2016, 12, 26), observed)  # Christmas - observed
         self.assertIn(date(2016, 12, 27), observed)  # Boxing day - observed
+
+    def test_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 1, 1), holidays)  # New Year
+        self.assertIn(date(2020, 4, 10), holidays)  # Good Friday
+        self.assertIn(date(2020, 4, 12), holidays)  # Easter Sunday
+        self.assertIn(date(2020, 4, 13), holidays)  # Easter Monday
+        # This is where the year 2020 becomes special:
+        # The Early May Bank Holiday has been moved to May 8th
+        # to commemorate the 75th anniversary of the end of WWII
+        self.assertNotIn(date(2020, 5, 4), holidays)
+        self.assertIn(date(2020, 5, 25), holidays)  # Spring Bank Holiday
+        self.assertIn(date(2020, 8, 31), holidays)  # Late Summer Bank Holiday
+        self.assertIn(date(2020, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2020, 12, 26), holidays)  # 'Boxing Day
+        self.assertIn(date(2020, 12, 28), holidays)  # Boxing Day Shift
+
+        # May the 8th is VE day
+        holidays = self.cal.holidays(2020)
+        holidays = dict(holidays)
+        self.assertIn(date(2020, 5, 8), holidays)
+        self.assertEqual(
+            holidays[date(2020, 5, 8)], "Early May bank holiday (VE day)"
+        )
 
 
 class UnitedKingdomNorthernIrelandTest(UnitedKingdomTest):

--- a/calendra/tests/test_europe.py
+++ b/calendra/tests/test_europe.py
@@ -143,7 +143,7 @@ class CaymanIslandsTest(GenericCalendarTest):
     def test_holidays_2017(self):
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 1, 1), holidays)
-        self.assertIn(date(2017, 1, 2), holidays)  # New Year boxing
+        self.assertNotIn(date(2017, 1, 2), holidays)  # New Year boxing
         self.assertIn(date(2017, 1, 23), holidays)  # National Heroes Day
         self.assertIn(date(2017, 3, 1), holidays)   # Ash Wednesday
         self.assertIn(date(2017, 4, 14), holidays)  # good friday
@@ -870,7 +870,7 @@ class UnitedKingdomTest(GenericCalendarTest):
     def test_year_2012(self):
         holidays = self.cal.holidays_set(2012)
         self.assertIn(date(2012, 1, 1), holidays)  # new year day
-        self.assertIn(date(2012, 1, 2), holidays)  # new year shift
+        self.assertNotIn(date(2012, 1, 2), holidays)  # new year shift
         self.assertIn(date(2012, 4, 6), holidays)  # good friday
         self.assertIn(date(2012, 4, 8), holidays)  # easter sunday
         self.assertIn(date(2012, 4, 9), holidays)  # easter monday

--- a/calendra/tests/test_europe.py
+++ b/calendra/tests/test_europe.py
@@ -936,15 +936,17 @@ class UnitedKingdomTest(GenericCalendarTest):
         self.assertIn(date(2020, 5, 25), holidays)  # Spring Bank Holiday
         self.assertIn(date(2020, 8, 31), holidays)  # Late Summer Bank Holiday
         self.assertIn(date(2020, 12, 25), holidays)  # Christmas Day
-        self.assertIn(date(2020, 12, 26), holidays)  # 'Boxing Day
-        self.assertIn(date(2020, 12, 28), holidays)  # Boxing Day Shift
+        self.assertIn(date(2020, 12, 26), holidays)  # Boxing Day
+
+        # Boxing observed
+        assert self.cal.is_observed_holiday(date(2020, 12, 28))
 
         # May the 8th is VE day
         holidays = self.cal.holidays(2020)
         holidays = dict(holidays)
         self.assertIn(date(2020, 5, 8), holidays)
         self.assertEqual(
-            holidays[date(2020, 5, 8)], "Early May bank holiday (VE day)"
+            holidays[date(2020, 5, 8)], "Early May Bank Holiday (VE day)"
         )
 
 

--- a/calendra/tests/test_germany.py
+++ b/calendra/tests/test_germany.py
@@ -131,6 +131,26 @@ class BavariaTest(GenericCalendarTest):
 class BerlinTest(GermanyTest):
     cal_class = Berlin
 
+    def test_extra_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertNotIn(date(2018, 3, 8), holidays)
+        self.assertNotIn(date(2018, 5, 8), holidays)
+
+    def test_extra_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 3, 8), holidays)
+        self.assertNotIn(date(2019, 5, 8), holidays)
+
+    def test_extra_2020(self):
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 3, 8), holidays)
+        self.assertIn(date(2020, 5, 8), holidays)
+
+    def test_extra_2021(self):
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 3, 8), holidays)
+        self.assertNotIn(date(2021, 5, 8), holidays)
+
 
 class BrandenburgTest(GenericCalendarTest):
     cal_class = Brandenburg

--- a/calendra/tests/test_global_registry.py
+++ b/calendra/tests/test_global_registry.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from ..registry import registry
+from ..registry_tools import registry
 
 
 class GlobalRegistry(TestCase):

--- a/calendra/tests/test_oceania.py
+++ b/calendra/tests/test_oceania.py
@@ -13,6 +13,7 @@ from ..oceania import (
     Victoria,
     WesternAustralia,
     MarshallIslands,
+    NewZealand
 )
 
 
@@ -62,9 +63,37 @@ class AustraliaCapitalTerritoryTest(AustraliaTest):
         self.assertIn(date(2013, 3, 30), holidays)  # Easter Saturday
         self.assertIn(date(2013, 4, 1), holidays)  # Easter Monday
         self.assertIn(date(2013, 6, 10), holidays)  # Queen's Bday
-        self.assertIn(date(2013, 9, 30), holidays)
+        self.assertIn(date(2013, 9, 30), holidays)  # Family & Community day
         self.assertIn(date(2013, 10, 7), holidays)  # Labour day october
         self.assertIn(date(2013, 12, 26), holidays)  # Boxing day
+
+    def test_family_community_day_before_2007(self):
+        # There were no Family and Community day before 2007
+        for year in range(1970, 2007):
+            self.assertIsNone(self.cal.get_family_community_day(year))
+            holidays = self.cal.holidays(year)
+            holidays = dict(holidays)
+            labels = holidays.values()
+            self.assertNotIn(self.cal._family_community_label, labels)
+
+    def test_family_community_day_2007_2017_presence(self):
+        # Family & Community day was included [2007 -> 2017]
+        for year in range(2007, 2018):
+            self.assertIsNotNone(self.cal.get_family_community_day(year))
+            holidays = self.cal.holidays(year)
+            holidays = dict(holidays)
+            labels = holidays.values()
+            self.assertIn(self.cal._family_community_label, labels)
+
+    def test_family_community_day_after_2017(self):
+        # Starting of 2018 this day would no longer exist
+        for year in range(2018, date.today().year + 1):
+            self.assertIsNone(self.cal.get_family_community_day(year))
+            holidays = self.cal.holidays(year)
+            holidays = dict(holidays)
+            labels = holidays.values()
+            print(labels)
+            self.assertNotIn(self.cal._family_community_label, labels)
 
     def test_reconciliation_day(self):
         reconciliation_day = self.cal.get_reconciliation_day(2017)
@@ -238,3 +267,60 @@ class MarshallIslandsTest(GenericCalendarTest):
         self.assertIn(date(2013, 12, 6), holidays)  # gospel day
         self.assertIn(date(2013, 12, 25), holidays)  # Xmas
         self.assertIn(date(2013, 12, 31), holidays)  # new year's eve
+
+
+class NewZealandTest(GenericCalendarTest):
+    cal_class = NewZealand
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)  # New Year's Day
+        self.assertIn(date(2018, 1, 2), holidays)  # Day after New Year's Day
+        self.assertIn(date(2018, 2, 6), holidays)  # Waitangi Day
+        self.assertIn(date(2018, 3, 30), holidays)  # Good Friday
+        self.assertIn(date(2018, 4, 2), holidays)  # Easter Monday
+        self.assertIn(date(2018, 4, 25), holidays)  # ANZAC Day
+        self.assertIn(date(2018, 6, 4), holidays)  # Queen's Birthday
+        self.assertIn(date(2018, 10, 22), holidays)  # Labour Day
+        self.assertIn(date(2018, 12, 25), holidays)  # Christmas Day
+        self.assertIn(date(2018, 12, 26), holidays)  # Boxing Day
+
+    def test_new_year_shift(self):
+        holidays = self.cal.holidays_set(2012)
+        # New Years was on a sunday
+        # Day After New Years is on the 2nd
+        self.assertIn(date(2012, 1, 2), holidays)
+        # New Years Shift is on the 3rd
+        self.assertIn(date(2012, 1, 3), holidays)
+
+    def test_anzac_shift(self):
+        holidays = self.cal.holidays_set(2010)
+        # 25th was a sunday
+        # ANZAC Day is on 25th
+        self.assertIn(date(2010, 4, 25), holidays)
+        # ANZAC Day Shift is on 26th
+        self.assertIn(date(2010, 4, 26), holidays)
+
+    def test_waitangi_shift(self):
+        holidays = self.cal.holidays_set(2016)
+        # 6th was a saturday
+        # Waitangi Day is on 6th
+        self.assertIn(date(2016, 2, 6), holidays)
+        # Waitangi Day Shift is on 7th
+        self.assertIn(date(2016, 2, 8), holidays)
+
+    def test_oceania_shift_2016(self):
+        holidays = self.cal.holidays_set(2016)
+        # Christmas day is on sunday in 2016
+        # Boxing day is on 26th
+        self.assertIn(date(2016, 12, 26), holidays)
+        # Christmas day shift on 27th
+        self.assertIn(date(2016, 12, 27), holidays)
+
+    def test_oceania_shift_2009(self):
+        holidays = self.cal.holidays_set(2009)
+        # Boxing day is on saturday in 2009
+        # Boxing day is on 26th
+        self.assertIn(date(2009, 12, 26), holidays)
+        # Boxing day shift on 28th
+        self.assertIn(date(2009, 12, 28), holidays)

--- a/calendra/tests/test_oceania.py
+++ b/calendra/tests/test_oceania.py
@@ -290,37 +290,38 @@ class NewZealandTest(GenericCalendarTest):
         # New Years was on a sunday
         # Day After New Years is on the 2nd
         self.assertIn(date(2012, 1, 2), holidays)
-        # New Years Shift is on the 3rd
-        self.assertIn(date(2012, 1, 3), holidays)
+        # New Years observed on the 3rd
+        assert self.cal.is_observed_holiday(date(2012, 1, 3))
 
     def test_anzac_shift(self):
         holidays = self.cal.holidays_set(2010)
         # 25th was a sunday
         # ANZAC Day is on 25th
         self.assertIn(date(2010, 4, 25), holidays)
-        # ANZAC Day Shift is on 26th
-        self.assertIn(date(2010, 4, 26), holidays)
+        # ANZAC Day observed on 26th
+        assert self.cal.is_observed_holiday(date(2010, 4, 26))
 
     def test_waitangi_shift(self):
         holidays = self.cal.holidays_set(2016)
         # 6th was a saturday
         # Waitangi Day is on 6th
         self.assertIn(date(2016, 2, 6), holidays)
-        # Waitangi Day Shift is on 7th
-        self.assertIn(date(2016, 2, 8), holidays)
+        # Waitangi Day observed on 8th
+        assert self.cal.is_observed_holiday(date(2016, 2, 8))
 
     def test_oceania_shift_2016(self):
         holidays = self.cal.holidays_set(2016)
         # Christmas day is on sunday in 2016
         # Boxing day is on 26th
         self.assertIn(date(2016, 12, 26), holidays)
-        # Christmas day shift on 27th
-        self.assertIn(date(2016, 12, 27), holidays)
+        # Christmas day observed on 26th and boxing day on 27th
+        assert self.cal.is_observed_holiday(date(2016, 12, 26))
+        assert self.cal.is_observed_holiday(date(2016, 12, 27))
 
     def test_oceania_shift_2009(self):
         holidays = self.cal.holidays_set(2009)
         # Boxing day is on saturday in 2009
         # Boxing day is on 26th
         self.assertIn(date(2009, 12, 26), holidays)
-        # Boxing day shift on 28th
-        self.assertIn(date(2009, 12, 28), holidays)
+        # Boxing day is observed on 28th
+        assert self.cal.is_observed_holiday(date(2009, 12, 28))

--- a/calendra/tests/test_registry.py
+++ b/calendra/tests/test_registry.py
@@ -38,20 +38,20 @@ class MockCalendarTest(TestCase):
         self.subregion = SubRegionCalendar
 
     def test_register(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         self.assertEqual(0, len(registry.region_registry.items()))
         registry.register('RE', self.region)
         self.assertEqual(1, len(registry.region_registry.items()))
         self.assertEqual(RegionCalendar, registry.region_registry['RE'])
 
     def test_get_calendar_class(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         calendar_class = registry.get_calendar_class('RE')
         self.assertEqual(calendar_class, RegionCalendar)
 
     def test_get_subregions(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         registry.register('RE-SR', self.subregion)
         registry.register('OR-SR', self.subregion)
@@ -60,7 +60,7 @@ class MockCalendarTest(TestCase):
         self.assertEqual(1, len(subregions))
 
     def test_get_items(self):
-        registry = IsoRegistry()
+        registry = IsoRegistry(load_standard_modules=False)
         registry.register('RE', self.region)
         registry.register('RE-SR', self.subregion)
         registry.register('OR-SR', self.subregion)

--- a/calendra/tests/test_registry.py
+++ b/calendra/tests/test_registry.py
@@ -1,7 +1,7 @@
 from datetime import date
 from unittest import TestCase
 
-from ..registry import IsoRegistry
+from ..registry_tools import IsoRegistry
 from ..core import Calendar
 
 

--- a/calendra/tests/test_registry_africa.py
+++ b/calendra/tests/test_registry_africa.py
@@ -10,7 +10,7 @@ from ..africa import (
     SouthAfrica,
 )
 
-from ..registry import registry
+from ..registry_tools import registry
 
 
 class RegistryAfrica(TestCase):

--- a/calendra/tests/test_registry_america.py
+++ b/calendra/tests/test_registry_america.py
@@ -27,7 +27,7 @@ from ..america import (
     Nunavut,
 
 )
-from ..america import Chile, Colombia, Mexico, Panama
+from ..america import Chile, Colombia, Mexico, Panama, Paraguay
 
 from ..registry import registry
 
@@ -89,6 +89,7 @@ class RegistryAmerica(TestCase):
         self.assertIn(Colombia, classes)
         self.assertIn(Mexico, classes)
         self.assertIn(Panama, classes)
+        self.assertIn(Paraguay, classes)
 
     def test_brazil_subregion(self):
         classes = (v for k, v in registry.get_subregions('BR').items())

--- a/calendra/tests/test_registry_america.py
+++ b/calendra/tests/test_registry_america.py
@@ -29,7 +29,7 @@ from ..america import (
 )
 from ..america import Chile, Colombia, Mexico, Panama, Paraguay
 
-from ..registry import registry
+from ..registry_tools import registry
 
 
 class RegistryAmerica(TestCase):

--- a/calendra/tests/test_registry_asia.py
+++ b/calendra/tests/test_registry_asia.py
@@ -12,7 +12,7 @@ from ..asia import (
     Taiwan,
 )
 
-from ..registry import registry
+from ..registry_tools import registry
 
 
 class RegistryAsia(TestCase):

--- a/calendra/tests/test_registry_asia.py
+++ b/calendra/tests/test_registry_asia.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 
 from ..asia import (
+    China,
     HongKong,
     Japan,
     Malaysia,
@@ -18,6 +19,7 @@ class RegistryAsia(TestCase):
     def test_asia(self):
         classes = (v for k, v in registry.region_registry.items())
         classes = list(classes)
+        self.assertIn(China, classes)
         self.assertIn(HongKong, classes)
         self.assertIn(Japan, classes)
         self.assertIn(Malaysia, classes)

--- a/calendra/tests/test_registry_europe.py
+++ b/calendra/tests/test_registry_europe.py
@@ -19,7 +19,7 @@ from ..europe import (
     SaxonyAnhalt, SchleswigHolstein, Thuringia
 )
 
-from ..registry import registry
+from ..registry_tools import registry
 
 classes = (v for k, v in registry.region_registry.items())
 classes = list(classes)

--- a/calendra/tests/test_registry_oceania.py
+++ b/calendra/tests/test_registry_oceania.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from ..oceania import (
     Australia,
     MarshallIslands,
+    NewZealand,
     # Australian territories
     AustralianCapitalTerritory,
     NewSouthWales,
@@ -37,6 +38,7 @@ class RegistryOceania(TestCase):
         classes = list(classes)
         self.assertIn(Australia, classes)
         self.assertIn(MarshallIslands, classes)
+        self.assertIn(NewZealand, classes)
         for klass in AUSTRALIAN_TERRITORIES:
             self.assertIn(klass, classes)
 

--- a/calendra/tests/test_registry_oceania.py
+++ b/calendra/tests/test_registry_oceania.py
@@ -18,7 +18,7 @@ from ..oceania import (
     WesternAustralia
 )
 
-from ..registry import registry
+from ..registry_tools import registry
 
 AUSTRALIAN_TERRITORIES = (
     AustralianCapitalTerritory,

--- a/calendra/tests/test_registry_usa.py
+++ b/calendra/tests/test_registry_usa.py
@@ -55,7 +55,7 @@ from ..usa import (
     Wyoming
 )
 
-from ..registry import registry
+from ..registry_tools import registry
 
 
 class RegistryUsa(TestCase):

--- a/calendra/tests/test_scotland.py
+++ b/calendra/tests/test_scotland.py
@@ -1,0 +1,628 @@
+from datetime import date
+from unittest import TestCase, skipIf
+import sys
+import warnings
+
+from ..tests import GenericCalendarTest
+from ..europe import (
+    Scotland, Aberdeen, Angus, Arbroath, Ayr, CarnoustieMonifieth, Clydebank,
+    DumfriesGalloway, Dundee, EastDunbartonshire, Edinburgh, Elgin, Falkirk,
+    Fife, Galashiels, Glasgow, Hawick, Inverclyde, Inverness, Kilmarnock,
+    Lanark, Linlithgow, Lochaber, NorthLanarkshire, Paisley, Perth,
+    ScottishBorders, SouthLanarkshire, Stirling, WestDunbartonshire,
+)
+
+
+PY2 = sys.version_info[0] == 2
+
+
+class GoodFridayTestMixin(object):
+    def test_good_friday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 3, 30), holidays)
+
+
+class EasterMondayTestMixin(object):
+    def test_easter_monday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 2), holidays)
+
+
+class SpringHolidayFirstMondayAprilTestMixin(object):
+    def test_spring_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 2), holidays)
+
+
+class SpringHolidaySecondMondayAprilTestMixin(object):
+    def test_spring_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 9), holidays)
+
+
+class SpringHolidayLastMondayMayTestMixin(object):
+    def test_spring_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 28), holidays)
+
+
+class FairHolidayLastMondayJuneTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 6, 25), holidays)
+
+
+class FairHolidayFirstMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 2), holidays)
+
+
+class FairHolidaySecondMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 9), holidays)
+
+
+class FairHolidayThirdMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 16), holidays)
+
+
+class FairHolidayLastMondayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 30), holidays)
+
+
+class FairHolidayFourthFridayJulyTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 7, 27), holidays)
+
+
+class FairHolidayFirstMondayAugustTestMixin(object):
+    def test_fair_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 8, 6), holidays)
+
+
+class LateSummerTestMixin(object):
+    def test_late_summer(self):
+        # First monday of september
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 3), holidays)
+
+
+class BattleStirlingBridgeTestMixin(object):
+    def test_stirling(self):
+        # Second monday of september
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 10), holidays)
+
+
+class AutumnHolidayLastMondaySeptemberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 24), holidays)
+
+
+class AutumnHolidayFirstMondayOctoberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 10, 1), holidays)
+
+
+class AutumnHolidaySecondMondayOctoberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 10, 8), holidays)
+
+
+class AutumnHolidayThirdMondayOctoberTestMixin(object):
+    def test_autumn_holiday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 10, 15), holidays)
+
+
+class SaintAndrewTestMixin(object):
+    def test_saint_andrew(self):
+        # St. Andrew's day happens on November 30th
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 11, 30), holidays)
+
+
+class VictoriaDayLastMondayMayTestMixin(object):
+    def test_victoria_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 28), holidays)
+
+
+class SpringHolidayTuesdayAfterFirstMondayMayTestMixin(object):
+    def test_spring_holiday_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 8), holidays)
+
+    def test_spring_holiday_2017(self):
+        holidays = self.cal.holidays_set(2017)
+        self.assertIn(date(2017, 5, 2), holidays)
+
+
+class VictoriaDayFirstMondayJuneTestMixin(object):
+    def test_victoria_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 6, 4), holidays)
+
+
+class VictoriaDayFourthMondayMayTestMixin(object):
+    def test_victoria_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 28), holidays)
+
+
+class AyrGoldCupTestMixin(object):
+    """
+    Ayr Gold cup - two holidays for Ayr and Kilmarnock
+    """
+    def test_ayr_gold_cup(self):
+        # Specific holidays in Ayr:
+        # * 3rd Friday in September
+        # * + the following Monday
+        holidays = self.cal.holidays_set(2018)
+        gold_cup_friday = date(2018, 9, 21)
+        gold_cup_monday = date(2018, 9, 24)
+        self.assertIn(gold_cup_friday, holidays)
+        self.assertIn(gold_cup_monday, holidays)
+        # Testing labels
+        holidays = self.cal.holidays(2018)
+        holidays_dict = dict(holidays)
+        self.assertEqual(holidays_dict[gold_cup_friday], "Ayr Gold Cup Friday")
+        self.assertEqual(holidays_dict[gold_cup_monday], "Ayr Gold Cup Monday")
+
+
+# -----------------------------------------------------------------------------
+class SpringHolidayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_spring_holiday = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_spring_holiday = True
+
+            def get_spring_holiday(self, year):
+                return (date(year, 1, 1), "Spring Holiday")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class VictoriaDayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_victoria_day = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_victoria_day = True
+
+            def get_victoria_day(self, year):
+                return (date(year, 1, 1), "Victoria Day")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class FairHolidayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_fair_holiday = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_fair_holiday = True
+
+            def get_fair_holiday(self, year):
+                return (date(year, 1, 1), "Fair Holiday")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class AutumnHolidayTestCase(TestCase):
+
+    def test_not_implemented_error(self):
+        class FakeCalendar(Scotland):
+            include_autumn_holiday = True
+
+        cal = FakeCalendar()
+        with self.assertRaises(NotImplementedError):
+            cal.holidays_set(2018)
+
+    def test_correct_implementation(self):
+        class FakeCalendar(Scotland):
+            include_autumn_holiday = True
+
+            def get_autumn_holiday(self, year):
+                return (date(year, 1, 1), "Autumn Holiday")
+
+        cal = FakeCalendar()
+        self.assertTrue(cal.holidays_set(2018))
+
+
+class ScotlandTest(GenericCalendarTest):
+    """
+    Generic Scotland test calendar.
+
+    Scotland calendar includes the generic holidays + GoodFriday
+    Some towns or cities don't necessarily observe it.
+    """
+    cal_class = Scotland
+
+    # For some reason, the Python 2 warnings module doesn't trigger a warning
+    # at each call of constructor ; skipping if we're in a Python2 env.
+    @skipIf(PY2, "Python 2 warnings unsupported")
+    def test_init_warning(self):
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            # Trigger a warning.
+            self.cal_class()
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "experimental" in str(w[-1].message)
+            # Back to normal filtering
+        warnings.simplefilter("ignore")
+
+    def test_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 1, 1), holidays)  # New year's day
+        self.assertIn(date(2018, 1, 2), holidays)  # New year holiday
+        self.assertIn(date(2018, 5, 7), holidays)  # May day
+        self.assertIn(date(2018, 12, 25), holidays)  # XMas
+        self.assertIn(date(2018, 12, 26), holidays)  # Boxing day
+
+    def test_good_friday(self):
+        # By default, Good Friday is not a holiday
+        holidays = self.cal.holidays_set(2018)
+        self.assertNotIn(date(2018, 3, 30), holidays)
+
+
+class ScotlandAberdeenTest(
+        GoodFridayTestMixin,
+        FairHolidaySecondMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = Aberdeen
+
+
+class ScotlandAngusTest(
+        SpringHolidaySecondMondayAprilTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        SaintAndrewTestMixin,
+        ScotlandTest):
+    cal_class = Angus
+
+
+class ScotlandArbroathTest(
+        FairHolidayThirdMondayJulyTestMixin, ScotlandTest):
+    cal_class = Arbroath
+
+
+class ScotlandAyrTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        AyrGoldCupTestMixin,
+        ScotlandTest):
+    cal_class = Ayr
+
+
+class ScotlandCarnoustieMonifiethTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = CarnoustieMonifieth
+
+
+class ScotlandClydebankTest(
+        SpringHolidayTuesdayAfterFirstMondayMayTestMixin,
+        ScotlandTest):
+    cal_class = Clydebank
+
+
+class ScotlandDumfriesGallowayTest(GoodFridayTestMixin, ScotlandTest):
+    cal_class = DumfriesGalloway
+
+
+class ScotlandDundeeTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        VictoriaDayLastMondayMayTestMixin,
+        FairHolidayLastMondayJulyTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Dundee
+
+
+class ScotlandEastDunbartonshireTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = EastDunbartonshire
+
+
+class ScotlandEdinburghTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        ScotlandTest):
+    cal_class = Edinburgh
+
+    def test_edinburgh_spring_holiday(self):
+        # Stated as the 3rd Monday in April...
+        holidays = self.cal.holidays_set(2018)
+        spring_holiday = date(2018, 4, 16)
+        self.assertIn(spring_holiday, holidays)
+        # ... except if it falls on Easter Monday
+        # Then it's shifted to the previous week.
+        # That was the case in 2017
+        holidays = self.cal.holidays(2017)
+        holidays_dict = dict(holidays)
+        easter_monday = date(2017, 4, 17)
+        spring_holiday = date(2017, 4, 10)
+        self.assertIn(easter_monday, holidays_dict)
+        self.assertIn(spring_holiday, holidays_dict)
+        self.assertEqual(holidays_dict[easter_monday], "Easter Monday")
+        self.assertEqual(holidays_dict[spring_holiday], "Spring Holiday")
+
+    def test_edinburgh_victoria_day(self):
+        # The Monday strictly before May 24th
+        holidays = self.cal.holidays_set(2018)
+        victoria_day = date(2018, 5, 21)
+        self.assertIn(victoria_day, holidays)
+        # In 2010, May 24th was a monday, so Victoria Day is on 17th.
+        holidays = self.cal.holidays_set(2010)
+        victoria_day = date(2010, 5, 17)
+        self.assertIn(victoria_day, holidays)
+
+    def test_edinbirgh_autumn_holiday(self):
+        # Third Monday in September
+        holidays = self.cal.holidays_set(2018)
+        autumn_holiday = date(2018, 9, 17)
+        self.assertIn(autumn_holiday, holidays)
+
+
+class ScotlandElginTest(
+        SpringHolidaySecondMondayAprilTestMixin,
+        FairHolidayLastMondayJuneTestMixin,
+        LateSummerTestMixin,
+        AutumnHolidayThirdMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Elgin
+
+
+class ScotlandFalkirkTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        FairHolidayFirstMondayJulyTestMixin,
+        BattleStirlingBridgeTestMixin,
+        ScotlandTest):
+    cal_class = Falkirk
+
+
+class ScotlandFifeTest(
+        VictoriaDayFirstMondayJuneTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayThirdMondayOctoberTestMixin,
+        SaintAndrewTestMixin,
+        ScotlandTest):
+    cal_class = Fife
+
+    def test_spring_holiday(self):
+        # Special computation rule, Fife has TWO spring holidays
+        holidays = self.cal.holidays_set(2018)
+        # First MON in April
+        self.assertIn(date(2018, 4, 2), holidays)
+        # First MON in June
+        self.assertIn(date(2018, 6, 4), holidays)
+
+
+class ScotlandGalashiels(VictoriaDayFirstMondayJuneTestMixin, ScotlandTest):
+    cal_class = Galashiels
+
+    def test_braw_lads_gathering(self):
+        # First friday in July
+        holidays = self.cal.holidays_set(2018)
+        braw_lads_gathering = date(2018, 7, 6)
+        self.assertIn(braw_lads_gathering, holidays)
+
+
+class ScotlandGlasgowTest(
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = Glasgow
+
+
+class ScotlandHawickTest(ScotlandTest):
+    cal_class = Hawick
+
+    def test_common_riding(self):
+        # Friday after first monday in june & saturday
+        holidays = self.cal.holidays_set(2018)
+        common_riding_day1 = date(2018, 6, 8)
+        common_riding_day2 = date(2018, 6, 9)
+        self.assertIn(common_riding_day1, holidays)
+        self.assertIn(common_riding_day2, holidays)
+
+
+# https://www.inverclyde.gov.uk/council-and-government/council-public-holidays
+# These documents say that Spring Holidays happened:
+# * on April 11th 2016 (second monday of April)
+# * on April 24th 2017 (last monday April)
+# * on April 16th 2018 (3rd monday April)
+# * on April 29th 2019 (last monday April)
+# ...
+# I think I'm becoming crazy
+class ScotlandInverclydeTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        LateSummerTestMixin,
+        ScotlandTest):
+    cal_class = Inverclyde
+
+    def test_spring_holiday(self):
+        # Special computation rule, Fife has TWO spring holidays
+        holidays = self.cal.holidays_set(2018)
+        # Last MON in April
+        self.assertIn(date(2018, 4, 30), holidays)
+        # First MON in June
+        self.assertIn(date(2018, 6, 4), holidays)
+
+
+class ScotlandInvernessTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        FairHolidayFirstMondayJulyTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Inverness
+
+    def test_winter_february(self):
+        # First MON of February
+        holidays = self.cal.holidays_set(2018)
+        winter_february = date(2018, 2, 5)
+        self.assertIn(winter_february, holidays)
+
+    def test_winter_march(self):
+        # First MON of March
+        holidays = self.cal.holidays_set(2018)
+        winter_march = date(2018, 3, 5)
+        self.assertIn(winter_march, holidays)
+
+    def test_samhain_holiday(self):
+        # First MON of November
+        holidays = self.cal.holidays_set(2018)
+        samhain_holiday = date(2018, 11, 5)
+        self.assertIn(samhain_holiday, holidays)
+
+
+class ScotlandKilmarnockTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        AyrGoldCupTestMixin,
+        ScotlandTest):
+    cal_class = Kilmarnock
+
+
+class ScotlandLanarkTest(ScotlandTest):
+    cal_class = Lanark
+
+    def test_lanimer_day(self):
+        # Second THU in June
+        holidays = self.cal.holidays_set(2018)
+        lanimer_day = date(2018, 6, 14)
+        self.assertIn(lanimer_day, holidays)
+
+
+class ScotlandLinlithgowTest(ScotlandTest):
+    cal_class = Linlithgow
+
+    def test_linlithgow_marches(self):
+        # Linlithgow marches is on TUE after the 2nd THU in June
+        holidays = self.cal.holidays_set(2018)
+        linlithgow_marches = date(2018, 6, 19)
+        self.assertIn(linlithgow_marches, holidays)
+
+
+class ScotlandLochaberTest(ScotlandTest):
+    cal_class = Lochaber
+
+    def test_winter_holiday(self):
+        # Winter holiday is on last MON in March.
+        holidays = self.cal.holidays_set(2018)
+        winter_holiday = date(2018, 3, 26)
+        self.assertIn(winter_holiday, holidays)
+        # Not the 4th, the *last*
+        holidays = self.cal.holidays_set(2015)
+        winter_holiday = date(2015, 3, 30)
+        self.assertIn(winter_holiday, holidays)
+
+
+class ScotlandNorthLanarkshireTest(
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = NorthLanarkshire
+
+
+class ScotlandPaisleyTest(
+        GoodFridayTestMixin, EasterMondayTestMixin,
+        VictoriaDayLastMondayMayTestMixin,
+        FairHolidayFirstMondayAugustTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = Paisley
+
+
+class ScotlandPerthTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        VictoriaDayFourthMondayMayTestMixin,
+        BattleStirlingBridgeTestMixin,
+        AutumnHolidayFirstMondayOctoberTestMixin,
+        ScotlandTest):
+    cal_class = Perth
+
+
+class ScotlandScottishBordersTest(
+        SpringHolidayFirstMondayAprilTestMixin,
+        FairHolidayFourthFridayJulyTestMixin,
+        AutumnHolidaySecondMondayOctoberTestMixin,
+        SaintAndrewTestMixin,
+        ScotlandTest):
+    cal_class = ScottishBorders
+
+
+class ScotlandSouthLanarkshireTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        SpringHolidayLastMondayMayTestMixin,
+        FairHolidayThirdMondayJulyTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = SouthLanarkshire
+
+
+class ScotlandStirlingTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        SpringHolidayTuesdayAfterFirstMondayMayTestMixin,
+        BattleStirlingBridgeTestMixin,
+        ScotlandTest):
+    cal_class = Stirling
+
+
+class ScotlandWestDunbartonshireTest(
+        GoodFridayTestMixin,
+        EasterMondayTestMixin,
+        AutumnHolidayLastMondaySeptemberTestMixin,
+        ScotlandTest):
+    cal_class = WestDunbartonshire

--- a/calendra/tests/test_turkey.py
+++ b/calendra/tests/test_turkey.py
@@ -11,7 +11,7 @@ class TurkeyTest(GenericCalendarTest):
     def test_year_new_year_shift(self):
         holidays = self.cal.holidays_set(2012)
         self.assertIn(date(2012, 1, 1), holidays)
-        self.assertIn(date(2012, 1, 2), holidays)
+        self.assertNotIn(date(2012, 1, 2), holidays)
         holidays = self.cal.holidays_set(2013)
         self.assertIn(date(2013, 1, 1), holidays)
         self.assertNotIn(date(2013, 1, 2), holidays)

--- a/calendra/tests/test_turkey.py
+++ b/calendra/tests/test_turkey.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from datetime import date
+
+from ..tests import GenericCalendarTest
+from ..europe.turkey import Turkey
+
+
+class TurkeyTest(GenericCalendarTest):
+    cal_class = Turkey
+
+    def test_year_new_year_shift(self):
+        holidays = self.cal.holidays_set(2012)
+        self.assertIn(date(2012, 1, 1), holidays)
+        self.assertIn(date(2012, 1, 2), holidays)
+        holidays = self.cal.holidays_set(2013)
+        self.assertIn(date(2013, 1, 1), holidays)
+        self.assertNotIn(date(2013, 1, 2), holidays)
+
+    def test_year_2014(self):
+        holidays = self.cal.holidays_set(2014)
+        # Fixed days section:
+        # 1. New years Day
+        self.assertIn(date(2014, 1, 1), holidays)
+        # 2. National Sovereignty and Children's Day
+        self.assertIn(date(2014, 4, 23), holidays)
+        # 3. Labor and Solidarity Day
+        self.assertIn(date(2014, 5, 1), holidays)
+        # 4. Commemoration of Atatürk, Youth and Sports Day
+        self.assertIn(date(2014, 5, 19), holidays)
+        # 5. Democracy and National Unity Day
+        self.assertIn(date(2014, 7, 15), holidays)
+        # 6. Victory Day
+        self.assertIn(date(2014, 8, 30), holidays)
+        # 7. Republic Day
+        self.assertIn(date(2014, 9, 29), holidays)
+
+    def test_year_2015(self):
+        holidays = self.cal.holidays_set(2015)
+        # Fixed days section:
+        # 1. New years Day
+        self.assertIn(date(2015, 1, 1), holidays)
+        # 2. National Sovereignty and Children's Day
+        self.assertIn(date(2015, 4, 23), holidays)
+        # 3. Labor and Solidarity Day
+        self.assertIn(date(2015, 5, 1), holidays)
+        # 4. Commemoration of Atatürk, Youth and Sports Day
+        self.assertIn(date(2015, 5, 19), holidays)
+        # 5. Democracy and National Unity Day
+        self.assertIn(date(2015, 7, 15), holidays)
+        # 6. Victory Day
+        self.assertIn(date(2015, 8, 30), holidays)
+        # 7. Republic Day
+        self.assertIn(date(2015, 9, 29), holidays)
+
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        # Fixed days section:
+        # 1. New years Day
+        self.assertIn(date(2019, 1, 1), holidays)
+        # 2. National Sovereignty and Children's Day
+        self.assertIn(date(2019, 4, 23), holidays)
+        # 3. Labor and Solidarity Day
+        self.assertIn(date(2019, 5, 1), holidays)
+        # 4. Commemoration of Atatürk, Youth and Sports Day
+        self.assertIn(date(2019, 5, 19), holidays)
+        # 5. Democracy and National Unity Day
+        self.assertIn(date(2019, 7, 15), holidays)
+        # 6. Victory Day
+        self.assertIn(date(2019, 8, 30), holidays)
+        # 7. Republic Day
+        self.assertIn(date(2019, 9, 29), holidays)
+
+        # Religious days
+        # Ramadan Feast - 3 days
+        self.assertIn(date(2019, 6, 4), holidays)
+        self.assertIn(date(2019, 6, 5), holidays)
+        self.assertIn(date(2019, 6, 6), holidays)
+        # Ramadan Feast - 4 days
+        self.assertIn(date(2019, 8, 11), holidays)
+        self.assertIn(date(2019, 8, 12), holidays)
+        self.assertIn(date(2019, 8, 13), holidays)
+        self.assertIn(date(2019, 8, 14), holidays)

--- a/calendra/tests/test_usa.py
+++ b/calendra/tests/test_usa.py
@@ -1,20 +1,32 @@
 # -*- coding: utf-8 -*-
-from unittest import skip
+from unittest import skip, skipIf
 from datetime import date
+import sys
+import warnings
 
 from . import GenericCalendarTest
 from ..usa import (
-    UnitedStates, Alabama, AlabamaBaldwinCounty, AlabamaMobileCounty,
-    AlabamaPerryCounty, Florida, Arkansas, Alaska, Arizona, California,
+    UnitedStates,
+    Alabama, AlabamaBaldwinCounty, AlabamaMobileCounty, AlabamaPerryCounty,
+    Arkansas, Alaska, Arizona,
+    # California and others
+    California, CaliforniaEducation, CaliforniaBerkeley,
+    CaliforniaSanFrancisco, CaliforniaWestHollywood,
+    # Florida and others
+    Florida, FloridaLegal, FloridaCircuitCourts, FloridaMiamiDade,
     Colorado, Connecticut, Delaware, DistrictOfColumbia, Georgia, Hawaii,
-    Indiana, Illinois, Idaho, Iowa,
-    Kansas, Kentucky, Louisiana, Maine, Maryland, Massachusetts, Minnesota,
-    Michigan, Mississippi, Missouri, Montana, Nebraska, Nevada, NewHampshire,
-    NewJersey, NewMexico, NewYork, NorthCarolina, NorthDakota, Ohio, Oklahoma,
-    Oregon, Pennsylvania, RhodeIsland, SouthCarolina, SouthDakota, Tennessee,
-    Texas, TexasBase, Utah, Vermont, Virginia, Washington, WestVirginia,
-    Wisconsin, Wyoming,
+    Indiana, Illinois, Idaho, Iowa, Kansas, Kentucky, Louisiana, Maine,
+    Maryland, Massachusetts, Minnesota, Michigan, Mississippi, Missouri,
+    Montana, Nebraska, Nevada, NewHampshire, NewJersey, NewMexico, NewYork,
+    NorthCarolina, NorthDakota, Ohio, Oklahoma, Oregon, Pennsylvania,
+    RhodeIsland, SouthCarolina, SouthDakota, Tennessee, TexasBase, Texas,
+    Utah, Vermont, Virginia, Washington, WestVirginia, Wisconsin, Wyoming,
+    # Other territories, cities...
+    AmericanSamoa, ChicagoIllinois, Guam, SuffolkCountyMassachusetts,
 )
+
+
+PY2 = sys.version_info[0] == 2
 
 
 class UnitedStatesTest(GenericCalendarTest):
@@ -458,6 +470,110 @@ class CaliforniaTest(NoColumbus, UnitedStatesTest):
         self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
 
 
+class CaliforniaEducationTest(CaliforniaTest):
+    cal_class = CaliforniaEducation
+
+    def test_specific_lincoln_birthday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 2, 12), holidays)  # Lincoln's Birthday
+
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 2, 12), holidays)  # Lincoln's Birthday
+
+        # Lincoln's Birthday wasn't included in 2009
+        holidays = self.cal.holidays_set(2009)
+        self.assertNotIn(date(2009, 2, 12), holidays)
+
+    def test_specific_native_american_day(self):
+        # Native American Day occurs on the 4th MON of September
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 9, 24), holidays)  # Native American Day
+
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 9, 23), holidays)  # Native American Day
+
+
+# Like California, except that it has:
+# * No Chavez Day,
+# * Includes Columbus day, but relabels it.
+# * Adds Lincoln's Birthday.
+class CaliforniaBerkeleyTest(UnitedStatesTest):
+    cal_class = CaliforniaBerkeley
+
+    def test_state_year_2014(self):
+        # Overwriting CaliforniaTest, there's no Chavez Day for Berkeley
+        holidays = self.cal.holidays_set(2014)
+        self.assertNotIn(date(2014, 3, 31), holidays)  # NO Cesar Chavez Day
+        self.assertIn(date(2014, 11, 28), holidays)  # Thanksgiving Friday
+
+    def test_state_year_2015(self):
+        # Overwriting CaliforniaTest, there's no Chavez Day for Berkeley
+        holidays = self.cal.holidays_set(2015)
+        self.assertNotIn(date(2015, 3, 31), holidays)  # NO Cesar Chavez Day
+        self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
+
+    def test_specific_lincoln_birthday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 2, 12), holidays)  # Lincoln's Birthday
+
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 2, 12), holidays)  # Lincoln's Birthday
+
+    def test_specific_malcomx_birthday(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 19), holidays)  # Malcom X Day
+
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 5, 19), holidays)  # Malcom X Day
+
+    def test_columbus_day_label(self):
+        # Overwrite UnitedStatesTest.test_columbus_day_label
+        _, label = self.cal.get_columbus_day(2019)
+        self.assertEqual(label, "Indigenous People's Day")
+
+
+# Like California, except:
+# * No Chavez Day,
+# * Added Columbus Day
+class CaliforniaSanFranciscoTest(UnitedStatesTest):
+    cal_class = CaliforniaSanFrancisco
+
+    def test_state_year_2014(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertNotIn(date(2014, 3, 31), holidays)  # NO Cesar Chavez Day
+        self.assertIn(date(2014, 11, 28), holidays)  # Thanksgiving Friday
+
+    def test_state_year_2015(self):
+        holidays = self.cal.holidays_set(2015)
+        self.assertNotIn(date(2015, 3, 31), holidays)  # NO Cesar Chavez Day
+        self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
+
+
+# Like California, except:
+# * No Chavez Day,
+# * No Thanksgiving Friday
+# * Added Harvey Milk Day
+class CaliforniaWestHollywoodTest(NoColumbus, UnitedStatesTest):
+    cal_class = CaliforniaWestHollywood
+
+    def test_state_year_2014(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertNotIn(date(2014, 3, 31), holidays)  # NO Cesar Chavez Day
+        self.assertNotIn(date(2014, 11, 28), holidays)  # Thanksgiving Friday
+
+    def test_state_year_2015(self):
+        holidays = self.cal.holidays_set(2015)
+        self.assertNotIn(date(2015, 3, 31), holidays)  # NO Cesar Chavez Day
+        self.assertNotIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
+
+    def test_harvey_milk_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 5, 22), holidays)  # Harvey Milk Day
+
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 5, 22), holidays)  # Harvey Milk Day
+
+
 class ColoradoTest(UnitedStatesTest):
     cal_class = Colorado
     # Colorado has only federal state holidays.
@@ -509,9 +625,13 @@ class DistrictOfColumbiaTest(InaugurationDay, UnitedStatesTest):
         self.assertIn(date(2016, 4, 16), holidays)  # Emancipation Day
 
 
-class FloridaTest(NoColumbus, NoPresidentialDay, UnitedStatesTest):
-    cal_class = Florida
+class FloridaBasicTest(object):
+    """
+    Core Florida tests.
 
+    The difference is that it includes the Thanksgiving Friday *and* its label
+    is renamed.
+    """
     def test_state_year_2014(self):
         holidays = self.cal.holidays_set(2014)
         self.assertIn(date(2014, 11, 28), holidays)  # Thanksgiving Friday
@@ -526,6 +646,136 @@ class FloridaTest(NoColumbus, NoPresidentialDay, UnitedStatesTest):
         # Overwrite UnitedStatesTest.test_thanksgiving_friday_label
         _, label = self.cal.get_thanksgiving_friday(2017)
         self.assertEqual(label, "Friday after Thanksgiving")
+
+
+class FloridaTest(NoColumbus, NoPresidentialDay, FloridaBasicTest,
+                  UnitedStatesTest):
+    """
+    Florida includes all federal holidays except
+    Washington's Birthday & Columbus day
+    """
+    cal_class = Florida
+
+
+class FloridaLegalTest(IncludeMardiGras, ElectionDayEveryYear,
+                       FloridaBasicTest, UnitedStatesTest):
+    """
+    Florida Legal Holidays include:
+
+    * All Florida State Holidays,
+    * Mardi Gras,
+    * Lincoln's Birthday,
+    * Susan B. Anthony Day,
+    * Washington's Birthday,
+    * Good Friday,
+    * Pascua Florida Day,
+    * Confederate Memorial Day,
+    * Jefferson Davies Birthday,
+    * Flag Day
+    * Columbus Day renamed as "Columbus and Farmers' Day"
+    * Election Day
+    """
+    cal_class = FloridaLegal
+
+    @skipIf(PY2, "Python 2 warnings unsupported")
+    def test_init_warning(self):
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            # Trigger a warning.
+            self.cal_class()
+            # Verify some things
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "Florida's laws separate the definitions between paid versus legal holidays." in str(w[-1].message)  # noqa
+        warnings.simplefilter("ignore")
+
+    def test_specific_lincoln_birthday(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 2, 12), holidays)  # Lincoln's Birthday
+
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 2, 12), holidays)  # Lincoln's Birthday
+
+    def test_susan_b_anthony_day(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 2, 15), holidays)  # Susan B. Anthony Day
+
+    def test_good_friday(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 4, 18), holidays)  # Good Friday
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 3), holidays)  # Good Friday
+
+    def test_pascua_florida_day(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 4, 2), holidays)  # Pascua Florida Day
+
+    def test_confederate_holidays(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 4, 26), holidays)  # Confederate Memorial Day
+        self.assertIn(date(2014, 6, 3), holidays)  # Jefferson Davis' birthday
+
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 26), holidays)  # Confederate Memorial Day
+        self.assertIn(date(2015, 6, 3), holidays)  # Jefferson Davis' birthday
+
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 4, 26), holidays)  # Confederate Memorial Day
+        self.assertIn(date(2018, 6, 3), holidays)  # Jefferson Davis' birthday
+
+    def test_flag_day(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 6, 14), holidays)  # Flag Day
+
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 6, 14), holidays)  # Flag Day
+
+    def test_columbus_day_label(self):
+        _, label = self.cal.get_columbus_day(2017)
+        self.assertEqual(label, "Columbus Day and Farmers' Day")
+
+
+class FloridaCircuitCourtsTest(NoColumbus, FloridaBasicTest, UnitedStatesTest):
+    cal_class = FloridaCircuitCourts
+
+    def test_good_friday(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 4, 18), holidays)  # Good Friday
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 4, 3), holidays)  # Good Friday
+
+    def test_rosh_hashanah_2018(self):
+        # src: https://www.firstjudicialcircuit.org/about-court/court-holidays
+        rosh_hashanah = self.cal.get_rosh_hashanah(2018)
+        self.assertEqual(rosh_hashanah, date(2018, 9, 10))
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(rosh_hashanah, holidays)
+
+    def test_rosh_hashanah_2019(self):
+        # src: https://www.firstjudicialcircuit.org/about-court/court-holidays
+        rosh_hashanah = self.cal.get_rosh_hashanah(2019)
+        self.assertEqual(rosh_hashanah, date(2019, 9, 30))
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(rosh_hashanah, holidays)
+
+    def test_yom_kippur_2018(self):
+        # src: https://www.firstjudicialcircuit.org/about-court/court-holidays
+        yom_kippur = self.cal.get_yom_kippur(2018)
+        self.assertEqual(yom_kippur, date(2018, 9, 19))
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(yom_kippur, holidays)
+
+    def test_yom_kippur_2019(self):
+        # src: https://www.firstjudicialcircuit.org/about-court/court-holidays
+        yom_kippur = self.cal.get_yom_kippur(2019)
+        self.assertEqual(yom_kippur, date(2019, 10, 9))
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(yom_kippur, holidays)
+
+
+class FloridaMiamiDadeTests(FloridaBasicTest, UnitedStatesTest):
+    cal_class = FloridaMiamiDade
 
 
 class GeorgiaTest(NoPresidentialDay, UnitedStatesTest):
@@ -628,6 +878,34 @@ class IllinoisTest(ElectionDayEvenYears, UnitedStatesTest):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 2, 12), holidays)  # Lincoln's Birthday
         self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
+
+
+class ChicagoIllinoisTest(ElectionDayEvenYears, UnitedStatesTest):
+    cal_class = ChicagoIllinois
+
+    def test_state_year_2014(self):
+        holidays = self.cal.holidays_set(2014)
+        self.assertIn(date(2014, 2, 12), holidays)  # Lincoln's Birthday
+        # Thanksgiving Friday is NOT a holiday in Chicago.
+        self.assertNotIn(date(2014, 11, 28), holidays)
+
+    def test_state_year_2015(self):
+        holidays = self.cal.holidays_set(2015)
+        self.assertIn(date(2015, 2, 12), holidays)  # Lincoln's Birthday
+        # Thanksgiving Friday is NOT a holiday in Chicago.
+        self.assertNotIn(date(2015, 11, 27), holidays)
+
+    def test_pulaski_day(self):
+        # Pulaski day is on the first MON in March.
+        # Source: https://en.wikipedia.org/wiki/Casimir_Pulaski_Day
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 3, 5), holidays)
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 3, 4), holidays)
+        holidays = self.cal.holidays_set(2020)
+        self.assertIn(date(2020, 3, 2), holidays)
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 3, 1), holidays)
 
 
 class IndianaTest(ElectionDayEvenYears, NoPresidentialDay, UnitedStatesTest):
@@ -796,6 +1074,20 @@ class MassachusettsTest(UnitedStatesTest):
     def test_state_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 4, 20), holidays)  # Patriot's day
+
+
+class SuffolkCountyMassachusettsTest(MassachusettsTest):
+    cal_class = SuffolkCountyMassachusetts
+
+    def test_county_year_2018(self):
+        holidays = self.cal.holidays_set(2018)
+        self.assertIn(date(2018, 3, 17), holidays)  # Evacuation Day
+        self.assertIn(date(2018, 6, 17), holidays)  # Bunker Hill Day
+
+    def test_county_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 3, 17), holidays)  # Evacuation Day
+        self.assertIn(date(2019, 6, 17), holidays)  # Bunker Hill Day
 
 
 class MichiganTest(NoColumbus, ElectionDayEvenYears, UnitedStatesTest):
@@ -993,6 +1285,7 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
     def test_state_year_2014(self):
         holidays = self.cal.holidays_set(2014)
         self.assertIn(date(2014, 4, 18), holidays)  # Good Friday
+        self.assertIn(date(2014, 11, 27), holidays)  # Thanksgiving Thursday
         self.assertIn(date(2014, 11, 28), holidays)  # Thanksgiving Friday
         self.assertIn(date(2014, 12, 24), holidays)  # XMas Eve
         self.assertIn(date(2014, 12, 26), holidays)  # Boxing Day
@@ -1000,6 +1293,7 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
     def test_state_year_2015(self):
         holidays = self.cal.holidays_set(2015)
         self.assertIn(date(2015, 4, 3), holidays)  # Good Friday
+        self.assertIn(date(2015, 11, 26), holidays)  # Thanksgiving Thursday
         self.assertIn(date(2015, 11, 27), holidays)  # Thanksgiving Friday
         self.assertIn(date(2015, 12, 24), holidays)  # Xmas Eve
         self.assertIn(date(2015, 12, 26), holidays)  # Boxing Day
@@ -1008,6 +1302,7 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
         # It is different from other federal days.
         holidays = self.cal.holidays_set(2017)
         self.assertIn(date(2017, 4, 14), holidays)  # Good Friday
+        self.assertIn(date(2017, 11, 23), holidays)  # Thanksgiving Thursday
         self.assertIn(date(2017, 11, 24), holidays)  # Thanksgiving Friday
         self.assertIn(date(2017, 12, 24), holidays)  # Xmas Eve
         self.assertIn(date(2017, 12, 25), holidays)  # Xmas Day
@@ -1045,15 +1340,35 @@ class NorthCarolinaTest(NoPresidentialDay, NoColumbus, UnitedStatesTest):
         self.assertNotIn(date(2018, 12, 23), holidays)
         self.assertNotIn(date(2018, 12, 27), holidays)
 
+    def test_state_year_2019_xmas(self):
+        # XMAS falls on WED
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 12, 24), holidays)  # Day 1 - TUE
+        self.assertIn(date(2019, 12, 25), holidays)  # Day 2 - WED
+        self.assertIn(date(2019, 12, 26), holidays)  # Day 3 - THU
+        # No shift:
+        self.assertNotIn(date(2019, 12, 23), holidays)
+        self.assertNotIn(date(2019, 12, 27), holidays)
+
     def test_state_year_2020_xmas(self):
         # XMAS falls on FRI
         holidays = self.cal.holidays_set(2020)
         self.assertIn(date(2020, 12, 24), holidays)  # Day 1 - THU
         self.assertIn(date(2020, 12, 25), holidays)  # Day 2 - FRI
         self.assertIn(date(2020, 12, 28), holidays)  # Day 3 - MON
-        # 23rd adn 29th are not included
+        # 23rd and 29th are not included
         self.assertNotIn(date(2020, 12, 23), holidays)
         self.assertNotIn(date(2020, 12, 29), holidays)
+
+    def test_state_year_2021_xmas(self):
+        # XMAS falls on SAT
+        holidays = self.cal.holidays_set(2021)
+        self.assertIn(date(2021, 12, 23), holidays)  # Day 1 - THU
+        self.assertIn(date(2021, 12, 24), holidays)  # Day 2 - FRI
+        self.assertIn(date(2021, 12, 27), holidays)  # Day 3 - MON
+        # 23rd and 29th are not included
+        self.assertNotIn(date(2021, 12, 22), holidays)
+        self.assertNotIn(date(2021, 12, 28), holidays)
 
 
 class NorthDakotaTest(NoColumbus, UnitedStatesTest):
@@ -1361,3 +1676,162 @@ class WyomingTest(UnitedStatesTest):
             label,
             "Martin Luther King, Jr. / Wyoming Equality Day"
         )
+
+
+class AmericanSamoaTest(UnitedStatesTest):
+    cal_class = AmericanSamoa
+
+    def test_family_day(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 12, 26), holidays)  # Family Day
+
+    def test_flag_day(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 4, 17), holidays)  # Flag Day
+
+    def test_family_day_label(self):
+        holidays = self.cal.holidays(2019)
+        holidays_dict = dict(holidays)
+        self.assertEqual(holidays_dict[date(2019, 12, 26)], "Family Day")
+
+
+class Guam(UnitedStatesTest):
+    cal_class = Guam
+
+    def test_state_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        # Guam History and Chamorro Heritage Day
+        self.assertIn(date(2019, 3, 7), holidays)
+        self.assertIn(date(2019, 7, 21), holidays)  # Liberation Day
+        self.assertIn(date(2019, 11, 2), holidays)  # All Souls Day
+        self.assertIn(date(2019, 12, 8), holidays)  # Lady of Camarin Day
+
+    def test_state_year_2018(self):
+        holidays = self.cal.holidays_set(2020)
+        # Guam History and Chamorro Heritage Day
+        self.assertIn(date(2020, 3, 7), holidays)
+        self.assertIn(date(2020, 7, 21), holidays)  # Liberation Day
+        self.assertIn(date(2020, 11, 2), holidays)  # All Souls Day
+        self.assertIn(date(2020, 12, 8), holidays)  # Lady of Camarin Day
+
+    def test_lady_of_camarin_label(self):
+        holidays = self.cal.holidays(2019)
+        holidays_dict = dict(holidays)
+        self.assertEqual(
+            holidays_dict[date(2019, 12, 8)],
+            "Lady of Camarin Day"
+        )
+
+
+class NormalShiftTestCase(UnitedStatesTest):
+    # Using a fake calendar here
+    class NormalShiftUnitedStates(UnitedStates):
+        "Normal Shift Fake United State calendar"
+        include_christmas_eve = True
+
+    cal_class = NormalShiftUnitedStates
+
+    def test_shift_2015(self):
+        # Test a normal shift on 4th of July.
+        # 2015: Happens on a Saturday, observed on FRI
+        holidays = self.cal.holidays(2015)
+        holiday_dict = dict(holidays)
+        fourth_july = date(2015, 7, 4)
+        observed = date(2015, 7, 3)
+        self.assertIn(fourth_july, holiday_dict)
+        self.assertEqual(holiday_dict[fourth_july], "Independence Day")
+        self.assertIn(observed, holiday_dict)
+        self.assertEqual(holiday_dict[observed], "Independence Day (Observed)")
+
+    def test_shift_2010(self):
+        # Test a normal shift on 4th of July.
+        # 2010: Happens on a SUN, observed on MON
+        holidays = self.cal.holidays(2010)
+        holiday_dict = dict(holidays)
+        fourth_july = date(2010, 7, 4)
+        observed = date(2010, 7, 5)
+        self.assertIn(fourth_july, holiday_dict)
+        self.assertEqual(holiday_dict[fourth_july], "Independence Day")
+        self.assertIn(observed, holiday_dict)
+        self.assertEqual(holiday_dict[observed], "Independence Day (Observed)")
+
+    def test_new_years_shift(self):
+        # If January, 1st *of the year after* happens on SAT, add New Years Eve
+        holidays = self.cal.holidays(2010)
+        holiday_dict = dict(holidays)
+        new_years_eve = date(2010, 12, 31)
+        self.assertIn(new_years_eve, holiday_dict)
+        self.assertEqual(
+            holiday_dict[new_years_eve],
+            "New Years Day (Observed)"
+        )
+        # The year after, it's not shifted
+        holidays = self.cal.holidays_set(2011)
+        new_years_eve = date(2011, 12, 31)
+        self.assertNotIn(new_years_eve, holidays)
+
+    def test_christmas_extra_shift_2010(self):
+        # XMAs Eve is included. *and* XMas falls on SAT.
+        # So you have the following holidays:
+        # * 24th & 25th (XMas Eve and XMas day)
+        # * 27th (XMas Shift)
+        # * 23rd (XMas Eve shifted on THU)
+        holidays = self.cal.holidays(2010)
+        holiday_dict = dict(holidays)
+        dec_23rd = date(2010, 12, 23)
+        dec_24th = date(2010, 12, 24)
+        dec_25th = date(2010, 12, 25)
+        for day in (dec_23rd, dec_24th, dec_25th):
+            self.assertIn(day, holiday_dict)
+        self.assertEqual(holiday_dict[dec_23rd], "Christmas Eve (Observed)")
+        self.assertEqual(holiday_dict[dec_24th], "Christmas Eve")
+        self.assertEqual(holiday_dict[dec_25th], "Christmas Day")
+
+    def test_christmas_extra_shift_2006(self):
+        # XMAs Eve is included. *and* XMas falls on MON.
+        # So you have the following holidays:
+        # * 24th & 25th (XMas Eve and XMas day)
+        # * 26th (XMas Shift)
+        holidays = self.cal.holidays(2006)
+        holiday_dict = dict(holidays)
+        dec_24th = date(2006, 12, 24)
+        dec_25th = date(2006, 12, 25)
+        dec_26th = date(2006, 12, 26)
+        for day in (dec_24th, dec_25th, dec_26th):
+            self.assertIn(day, holiday_dict)
+        self.assertEqual(holiday_dict[dec_24th], "Christmas Eve")
+        self.assertEqual(holiday_dict[dec_25th], "Christmas Day")
+        self.assertEqual(holiday_dict[dec_26th], "Christmas Day (Observed)")
+
+
+class NormalShiftTestCaseExceptions(UnitedStatesTest):
+    # Using a fake calendar here
+    class NormalShiftUnitedStatesExceptions(UnitedStates):
+        "Normal Shift Fake United State calendar"
+        shift_exceptions = (
+            (7, 4),  # Month/Day == Fourth of July.
+        )
+
+    cal_class = NormalShiftUnitedStatesExceptions
+
+    def test_shift_2015(self):
+        # Test a normal shift on 4th of July.
+        # 2015: Happens on a Saturday, not shifted
+        holidays = self.cal.holidays(2015)
+        holiday_dict = dict(holidays)
+        fourth_july = date(2015, 7, 4)
+        observed = date(2015, 7, 3)
+        self.assertIn(fourth_july, holiday_dict)
+        self.assertEqual(holiday_dict[fourth_july], "Independence Day")
+        self.assertNotIn(observed, holiday_dict)
+
+    def test_shift_2010(self):
+        # Test a normal shift on 4th of July.
+        # 2010: Happens on a SUN, not shifted
+        holidays = self.cal.holidays(2010)
+        holiday_dict = dict(holidays)
+        fourth_july = date(2010, 7, 4)
+        observed = date(2010, 7, 5)
+        self.assertIn(fourth_july, holiday_dict)
+        self.assertEqual(holiday_dict[fourth_july], "Independence Day")
+        self.assertNotIn(observed, holiday_dict)

--- a/calendra/tests/test_usa.py
+++ b/calendra/tests/test_usa.py
@@ -1740,8 +1740,7 @@ class NormalShiftTestCase(UnitedStatesTest):
         observed = date(2015, 7, 3)
         self.assertIn(fourth_july, holiday_dict)
         self.assertEqual(holiday_dict[fourth_july], "Independence Day")
-        self.assertIn(observed, holiday_dict)
-        self.assertEqual(holiday_dict[observed], "Independence Day (Observed)")
+        self.assertNotIn(observed, holiday_dict)
 
     def test_shift_2010(self):
         # Test a normal shift on 4th of July.
@@ -1752,19 +1751,14 @@ class NormalShiftTestCase(UnitedStatesTest):
         observed = date(2010, 7, 5)
         self.assertIn(fourth_july, holiday_dict)
         self.assertEqual(holiday_dict[fourth_july], "Independence Day")
-        self.assertIn(observed, holiday_dict)
-        self.assertEqual(holiday_dict[observed], "Independence Day (Observed)")
+        self.assertNotIn(observed, holiday_dict)
 
     def test_new_years_shift(self):
         # If January, 1st *of the year after* happens on SAT, add New Years Eve
         holidays = self.cal.holidays(2010)
         holiday_dict = dict(holidays)
         new_years_eve = date(2010, 12, 31)
-        self.assertIn(new_years_eve, holiday_dict)
-        self.assertEqual(
-            holiday_dict[new_years_eve],
-            "New Years Day (Observed)"
-        )
+        self.assertNotIn(new_years_eve, holiday_dict)
         # The year after, it's not shifted
         holidays = self.cal.holidays_set(2011)
         new_years_eve = date(2011, 12, 31)
@@ -1778,12 +1772,10 @@ class NormalShiftTestCase(UnitedStatesTest):
         # * 23rd (XMas Eve shifted on THU)
         holidays = self.cal.holidays(2010)
         holiday_dict = dict(holidays)
-        dec_23rd = date(2010, 12, 23)
         dec_24th = date(2010, 12, 24)
         dec_25th = date(2010, 12, 25)
-        for day in (dec_23rd, dec_24th, dec_25th):
+        for day in (dec_24th, dec_25th):
             self.assertIn(day, holiday_dict)
-        self.assertEqual(holiday_dict[dec_23rd], "Christmas Eve (Observed)")
         self.assertEqual(holiday_dict[dec_24th], "Christmas Eve")
         self.assertEqual(holiday_dict[dec_25th], "Christmas Day")
 
@@ -1796,12 +1788,10 @@ class NormalShiftTestCase(UnitedStatesTest):
         holiday_dict = dict(holidays)
         dec_24th = date(2006, 12, 24)
         dec_25th = date(2006, 12, 25)
-        dec_26th = date(2006, 12, 26)
-        for day in (dec_24th, dec_25th, dec_26th):
+        for day in (dec_24th, dec_25th):
             self.assertIn(day, holiday_dict)
         self.assertEqual(holiday_dict[dec_24th], "Christmas Eve")
         self.assertEqual(holiday_dict[dec_25th], "Christmas Day")
-        self.assertEqual(holiday_dict[dec_26th], "Christmas Day (Observed)")
 
 
 class NormalShiftTestCaseExceptions(UnitedStatesTest):

--- a/calendra/usa/__init__.py
+++ b/calendra/usa/__init__.py
@@ -8,16 +8,21 @@ from .alabama import (
 from .alaska import Alaska
 from .arizona import Arizona
 from .arkansas import Arkansas
-from .california import California
+from .california import (
+    California, CaliforniaEducation, CaliforniaBerkeley,
+    CaliforniaSanFrancisco, CaliforniaWestHollywood,
+)
 from .colorado import Colorado
 from .connecticut import Connecticut
 from .delaware import Delaware
 from .district_columbia import DistrictOfColumbia
-from .florida import Florida
+from .florida import (
+    Florida, FloridaLegal, FloridaCircuitCourts, FloridaMiamiDade
+)
 from .georgia import Georgia
 from .hawaii import Hawaii
 from .idaho import Idaho
-from .illinois import Illinois
+from .illinois import Illinois, ChicagoIllinois
 from .indiana import Indiana
 from .iowa import Iowa
 from .kansas import Kansas
@@ -25,7 +30,7 @@ from .kentucky import Kentucky
 from .louisiana import Louisiana
 from .maine import Maine
 from .maryland import Maryland
-from .massachusetts import Massachusetts
+from .massachusetts import Massachusetts, SuffolkCountyMassachusetts
 from .michigan import Michigan
 from .minnesota import Minnesota
 from .mississippi import Mississippi
@@ -55,8 +60,10 @@ from .washington import Washington
 from .west_virginia import WestVirginia
 from .wisconsin import Wisconsin
 from .wyoming import Wyoming
+# Non-states territories and areas
+from .american_samoa import AmericanSamoa
+from .guam import Guam
 
-NONE, NEAREST_WEEKDAY, MONDAY = range(3)
 
 __all__ = [
     'UnitedStates',  # Generic federal calendar
@@ -66,15 +73,17 @@ __all__ = [
     'Arizona',
     'Arkansas',
     'California',
+    'CaliforniaEducation', 'CaliforniaBerkeley', 'CaliforniaSanFrancisco',
+    'CaliforniaWestHollywood',
     'Colorado',
     'Connecticut',
     'Delaware',
     'DistrictOfColumbia',
-    'Florida',
+    'Florida', 'FloridaLegal', 'FloridaCircuitCourts', 'FloridaMiamiDade',
     'Georgia',
     'Hawaii',
     'Idaho',
-    'Illinois',
+    'Illinois', 'ChicagoIllinois',
     'Indiana',
     'Iowa',
     'Kansas',
@@ -82,7 +91,7 @@ __all__ = [
     'Louisiana',
     'Maine',
     'Maryland',
-    'Massachusetts',
+    'Massachusetts', 'SuffolkCountyMassachusetts',
     'Michigan',
     'Minnesota',
     'Mississippi',
@@ -113,4 +122,7 @@ __all__ = [
     'WestVirginia',
     'Wisconsin',
     'Wyoming',
+    # Non-State territories
+    'AmericanSamoa',
+    'Guam',
 ]

--- a/calendra/usa/alabama.py
+++ b/calendra/usa/alabama.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from .core import UnitedStates
 from ..core import MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AL')
@@ -15,20 +15,7 @@ class Alabama(UnitedStates):
     presidents_day_label = "George Washington/Thomas Jefferson Birthday"
     columbus_day_label = ("Columbus Day / Fraternal Day /"
                           " American Indian Heritage Day")
-
-    def get_jefferson_davis_birthday(self, year):
-        """
-        The first MON of June is Jefferson Davis Birthday
-        """
-        return (
-            self.get_nth_weekday_in_month(year, 6, MON, 1),
-            "Jefferson Davis Birthday"
-        )
-
-    def get_variable_days(self, year):
-        days = super(Alabama, self).get_variable_days(year)
-        days.append(self.get_jefferson_davis_birthday(year))
-        return days
+    include_jefferson_davis_birthday = True
 
 
 class AlabamaBaldwinCounty(Alabama):

--- a/calendra/usa/alaska.py
+++ b/calendra/usa/alaska.py
@@ -7,7 +7,7 @@ import datetime
 from .core import UnitedStates
 from ..core import MON
 from ..core import Holiday
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AK')

--- a/calendra/usa/american_samoa.py
+++ b/calendra/usa/american_samoa.py
@@ -1,0 +1,29 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from datetime import date
+
+from .core import UnitedStates
+from ..registry_tools import iso_register
+
+
+@iso_register('US-AS')
+class AmericanSamoa(UnitedStates):
+    "American Samoa"
+    include_boxing_day = True
+    boxing_day_label = "Family Day"
+
+    def get_flag_day(self, year):
+        """
+        Flag day is on April 17th
+        """
+        return (
+            date(year, 4, 17),
+            "Flag Day"
+        )
+
+    def get_variable_days(self, year):
+        days = super(AmericanSamoa, self).get_variable_days(year)
+        days.extend([
+            self.get_flag_day(year),
+        ])
+        return days

--- a/calendra/usa/arizona.py
+++ b/calendra/usa/arizona.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AZ')

--- a/calendra/usa/arkansas.py
+++ b/calendra/usa/arkansas.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-AR')

--- a/calendra/usa/california.py
+++ b/calendra/usa/california.py
@@ -3,7 +3,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..core import MON
+from ..registry_tools import iso_register
 
 
 @iso_register('US-CA')
@@ -12,3 +13,58 @@ class California(UnitedStates):
     include_thanksgiving_friday = True
     include_cesar_chavez_day = True
     include_columbus_day = False
+
+
+class CaliforniaEducation(California):
+    """California Education
+
+    This administration holds its own calendar. In order to respect the goal
+    of workalendar (to compute (non)working days), we've decided to only retain
+    days when the schools are closed.
+    """
+
+    def get_variable_days(self, year):
+        # usual variable days
+        days = super(CaliforniaEducation, self).get_variable_days(year)
+
+        if year != 2009:
+            days.append(self.get_lincoln_birthday(year))
+
+        days.append((
+            self.get_nth_weekday_in_month(year, 9, MON, 4),
+            'Native American Day'
+        ))
+
+        return days
+
+
+class CaliforniaBerkeley(California):
+    """
+    Berkeley, California
+    """
+    FIXED_HOLIDAYS = California.FIXED_HOLIDAYS + (
+        (5, 19, 'Malcolm X Day'),
+    )
+    include_cesar_chavez_day = False
+    include_lincoln_birthday = True
+    include_columbus_day = True
+    columbus_day_label = "Indigenous People's Day"
+
+
+class CaliforniaSanFrancisco(California):
+    """
+    San Francisco, California
+    """
+    include_cesar_chavez_day = False
+    include_columbus_day = True
+
+
+class CaliforniaWestHollywood(California):
+    """
+    West Hollywood, California
+    """
+    FIXED_HOLIDAYS = California.FIXED_HOLIDAYS + (
+        (5, 22, 'Harvey Milk Day'),
+    )
+    include_cesar_chavez_day = False
+    include_thanksgiving_friday = False

--- a/calendra/usa/colorado.py
+++ b/calendra/usa/colorado.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-CO')

--- a/calendra/usa/connecticut.py
+++ b/calendra/usa/connecticut.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-CT')

--- a/calendra/usa/core.py
+++ b/calendra/usa/core.py
@@ -84,55 +84,6 @@ class UnitedStates(WesternCalendar, ChristianMixin):
         # (11, 11),  # Veterans day won't be shifted
     )
 
-    def shift(self, holidays, year):
-        new_holidays = []
-        holiday_lookup = [x[0] for x in holidays]
-        exceptions = [
-            date(year, month, day) for month, day in self.shift_exceptions
-        ]
-
-        # For each holiday available:
-        # * if it falls on SUN, add the observed on MON
-        # * if it falls on SAT, add the observed on FRI
-        for day, label in holidays:
-            # ... except if it's been explicitely excepted.
-            if day in exceptions:
-                continue
-            if day.weekday() == SAT:
-                new_holidays.append((day - timedelta(days=1),
-                                     label + " (Observed)"))
-            elif day.weekday() == SUN:
-                new_holidays.append((day + timedelta(days=1),
-                                     label + " (Observed)"))
-
-        # If year+1 January the 1st is on SAT, add the FRI before to observed
-        if date(year + 1, 1, 1).weekday() == SAT:
-            new_holidays.append((date(year, 12, 31,),
-                                 "New Years Day (Observed)"))
-
-        # Special rules for XMas and XMas Eve
-        christmas = date(year, 12, 25)
-        christmas_eve = date(year, 12, 24)
-        # Is XMas eve in your calendar?
-        if christmas_eve in holiday_lookup:
-            # You are observing the THU before, as an extra XMas Eve
-            if christmas.weekday() == SAT:
-                # Remove the "fake" XMAS Day shift, the one done before.
-                new_holidays.remove(
-                    (christmas_eve, "Christmas Day (Observed)")
-                )
-                new_holidays.append((date(year, 12, 23),
-                                     "Christmas Eve (Observed)"))
-            # You are observing the 26th (TUE)
-            elif christmas.weekday() == MON:
-                # Remove the "fake" XMAS Eve shift, done before
-                new_holidays.remove(
-                    (christmas, "Christmas Eve (Observed)")
-                )
-                new_holidays.append((date(year, 12, 26),
-                                     "Christmas Day (Observed)"))
-        return holidays + new_holidays
-
     @staticmethod
     def is_presidential_year(year):
         return (year % 4) == 0

--- a/calendra/usa/delaware.py
+++ b/calendra/usa/delaware.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-DE')

--- a/calendra/usa/district_columbia.py
+++ b/calendra/usa/district_columbia.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-DC')

--- a/calendra/usa/florida.py
+++ b/calendra/usa/florida.py
@@ -1,9 +1,68 @@
 # -*- coding: utf-8 -*-
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+from __future__ import absolute_import, unicode_literals
+
+from datetime import date, timedelta
+import warnings
+from pyluach.dates import GregorianDate
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
+
+
+class HebrewHolidays(object):
+
+    hebrew_calendars = {}
+
+    @classmethod
+    def get_hebrew_calendar(cls, gregorian_year):
+        """
+        Build and cache the Hebrew calendar for the given Gregorian Year.
+        """
+        if gregorian_year not in cls.hebrew_calendars:
+            # Build the hebrew calendar for year
+            days = []
+            current_date = date(gregorian_year, 1, 1)
+
+            while current_date.year == gregorian_year:
+                hebrew_date = GregorianDate(
+                    year=current_date.year,
+                    month=current_date.month,
+                    day=current_date.day,
+                ).to_heb()
+                days.append(
+                    (hebrew_date, current_date)
+                )
+                current_date += timedelta(days=1)
+            # Store it in the class property
+            cls.hebrew_calendars[gregorian_year] = days
+
+        # Return the hebrew calendar
+        return cls.hebrew_calendars[gregorian_year]
+
+    @classmethod
+    def search_hebrew_calendar(cls, gregorian_year, hebrew_month, hebrew_day):
+        """
+        Search for a specific Hebrew month and day in the Hebrew calendar.
+        """
+        calendar = cls.get_hebrew_calendar(gregorian_year)
+        search = filter(lambda item: item[0].month == hebrew_month, calendar)
+        search = filter(lambda item: item[0].day == hebrew_day, search)
+        for item in search:
+            return item[1]
+
+    @classmethod
+    def get_rosh_hashanah(cls, year):
+        """
+        Return the gregorian date of the first day of Rosh Hashanah
+        """
+        return cls.search_hebrew_calendar(year, 7, 1)
+
+    @classmethod
+    def get_yom_kippur(cls, year):
+        """
+        Return the gregorian date of Yom Kippur.
+        """
+        return cls.search_hebrew_calendar(year, 7, 10)
 
 
 @iso_register('US-FL')
@@ -13,3 +72,68 @@ class Florida(UnitedStates):
     thanksgiving_friday_label = "Friday after Thanksgiving"
     include_columbus_day = False
     include_federal_presidents_day = False
+
+
+class FloridaLegal(Florida):
+    """Florida Legal Holidays"""
+    FIXED_HOLIDAYS = Florida.FIXED_HOLIDAYS + (
+        (2, 15, 'Susan B. Anthony Day'),
+        (4, 2, 'Pascua Florida Day'),
+        (6, 14, 'Flag Day'),
+    )
+    include_mardi_gras = True
+    include_lincoln_birthday = True
+    include_federal_presidents_day = True
+    include_good_friday = True
+    include_confederation_day = True
+    include_jefferson_davis_birthday = True
+    include_columbus_day = True
+    columbus_day_label = "Columbus Day and Farmers' Day"
+    include_election_day_every_year = True
+
+    def __init__(self, *args, **kwargs):
+        super(FloridaLegal, self).__init__(*args, **kwargs)
+        warnings.warn(
+            "Florida's laws separate the definitions between paid versus legal"
+            " holidays. Be warned that Florida Legal specific Holidays are not"
+            " paid holidays."
+        )
+
+    def get_confederate_day(self, year):
+        """
+        Confederation memorial day is on the April 26th for Florida Legal.
+        """
+        return (date(year, 4, 26), "Confederate Memorial Day")
+
+    def get_jefferson_davis_birthday(self, year):
+        """
+        Jefferson Davis Birthday appears to be a fixed holiday (June 3rd)
+        """
+        return (date(year, 6, 3), "Jefferson Davis Birthday")
+
+
+class FloridaCircuitCourts(HebrewHolidays, Florida):
+    """Florida Circuits Courts"""
+    include_federal_presidents_day = True
+    include_good_friday = True
+
+    def get_variable_days(self, year):
+        days = super(FloridaCircuitCourts, self).get_variable_days(year)
+
+        days.append((
+            self.get_rosh_hashanah(year),
+            "Rosh Hashanah"
+        ))
+
+        days.append((
+            self.get_yom_kippur(year),
+            "Yom Kippur"
+        ))
+
+        return days
+
+
+class FloridaMiamiDade(Florida):
+    """Miami-Dade, Florida"""
+    include_federal_presidents_day = True
+    include_columbus_day = True

--- a/calendra/usa/georgia.py
+++ b/calendra/usa/georgia.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 from datetime import date
 from ..core import MON, TUE, WED, THU, FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/guam.py
+++ b/calendra/usa/guam.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .core import UnitedStates
+from ..registry_tools import iso_register
+
+
+@iso_register('US-GU')
+class Guam(UnitedStates):
+    """Guam"""
+    FIXED_HOLIDAYS = UnitedStates.FIXED_HOLIDAYS + (
+        (3, 7, 'Guam History and Chamorro Heritage Day'),
+        (7, 21, 'Liberation Day'),
+    )
+    include_all_souls = True
+    include_immaculate_conception = True
+    immaculate_conception_label = "Lady of Camarin Day"

--- a/calendra/usa/hawaii.py
+++ b/calendra/usa/hawaii.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 from .core import UnitedStates
 

--- a/calendra/usa/idaho.py
+++ b/calendra/usa/idaho.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-ID')

--- a/calendra/usa/illinois.py
+++ b/calendra/usa/illinois.py
@@ -3,7 +3,8 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
+from ..core import MON
 
 
 @iso_register('US-IL')
@@ -12,3 +13,26 @@ class Illinois(UnitedStates):
     include_thanksgiving_friday = True
     include_lincoln_birthday = True
     include_election_day_even = True
+
+
+class ChicagoIllinois(Illinois):
+    "Chicago, Illinois"
+    include_thanksgiving_friday = False
+
+    def get_pulaski_day(self, year):
+        """
+        Return Casimir Pulaski Day.
+
+        Defined on the first MON of March.
+        ref: https://en.wikipedia.org/wiki/Casimir_Pulaski_Day
+        """
+        day = self.get_nth_weekday_in_month(year, 3, MON)
+        return (
+            day,
+            "Casimir Pulaski Day"
+        )
+
+    def get_variable_days(self, year):
+        days = super(ChicagoIllinois, self).get_variable_days(year)
+        days.append(self.get_pulaski_day(year))
+        return days

--- a/calendra/usa/indiana.py
+++ b/calendra/usa/indiana.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 from datetime import date
 from ..core import MON, TUE, WED, THU, FRI, SAT
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 from .core import UnitedStates
 

--- a/calendra/usa/iowa.py
+++ b/calendra/usa/iowa.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/kansas.py
+++ b/calendra/usa/kansas.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 # FIXME: According to wikipedia, Kansas only has all federal holidays, except
 # the Columbus Day and Washington's Birthday.

--- a/calendra/usa/kentucky.py
+++ b/calendra/usa/kentucky.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-KY')

--- a/calendra/usa/louisiana.py
+++ b/calendra/usa/louisiana.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-LA')

--- a/calendra/usa/maine.py
+++ b/calendra/usa/maine.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-ME')

--- a/calendra/usa/maryland.py
+++ b/calendra/usa/maryland.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MD')

--- a/calendra/usa/massachusetts.py
+++ b/calendra/usa/massachusetts.py
@@ -3,10 +3,18 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MA')
 class Massachusetts(UnitedStates):
     """Massachusetts"""
     include_patriots_day = True
+
+
+class SuffolkCountyMassachusetts(Massachusetts):
+    """Suffolk County, Massachusetts"""
+    FIXED_HOLIDAYS = UnitedStates.FIXED_HOLIDAYS + (
+        (3, 17, 'Evacuation Day'),
+        (6, 17, 'Bunker Hill Day'),
+    )

--- a/calendra/usa/michigan.py
+++ b/calendra/usa/michigan.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import date
 from ..core import SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 from .core import UnitedStates
 

--- a/calendra/usa/minnesota.py
+++ b/calendra/usa/minnesota.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/mississippi.py
+++ b/calendra/usa/mississippi.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MS')

--- a/calendra/usa/missouri.py
+++ b/calendra/usa/missouri.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MO')

--- a/calendra/usa/montana.py
+++ b/calendra/usa/montana.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import warnings
 
 from .core import UnitedStates
-from ..registry import iso_register
+from ..registry_tools import iso_register
 
 
 @iso_register('US-MT')

--- a/calendra/usa/nebraska.py
+++ b/calendra/usa/nebraska.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/nevada.py
+++ b/calendra/usa/nevada.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/new_hampshire.py
+++ b/calendra/usa/new_hampshire.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/new_jersey.py
+++ b/calendra/usa/new_jersey.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/new_mexico.py
+++ b/calendra/usa/new_mexico.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/new_york.py
+++ b/calendra/usa/new_york.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/north_carolina.py
+++ b/calendra/usa/north_carolina.py
@@ -2,11 +2,10 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import warnings
 from datetime import date
 
 from ..core import MON, TUE, WED, THU, FRI, SAT, SUN
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 
@@ -36,14 +35,9 @@ class NorthCarolina(UnitedStates):
                 (date(year, 12, 28), "Boxing day shift"),
             ]
         elif xmas.weekday() == SAT:
-            warnings.warn(
-                "We didn't find any documentation about this configuration for"
-                " the Christmas shift. Please use with care or help us build"
-                " a better Calendra"
-            )
             return [
-                (date(year, 12, 27), "Christmas Day shift"),
-                (date(year, 12, 28), "Boxing Day shift"),
+                (date(year, 12, 23), "Christmas Eve shift"),
+                (date(year, 12, 27), "Boxing Day shift"),
             ]
         elif xmas.weekday() == SUN:
             return [

--- a/calendra/usa/north_dakota.py
+++ b/calendra/usa/north_dakota.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/ohio.py
+++ b/calendra/usa/ohio.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/oklahoma.py
+++ b/calendra/usa/oklahoma.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/oregon.py
+++ b/calendra/usa/oregon.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/pennsylvania.py
+++ b/calendra/usa/pennsylvania.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/rhode_island.py
+++ b/calendra/usa/rhode_island.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import MON
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/south_carolina.py
+++ b/calendra/usa/south_carolina.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/south_dakota.py
+++ b/calendra/usa/south_dakota.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/tennessee.py
+++ b/calendra/usa/tennessee.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/texas.py
+++ b/calendra/usa/texas.py
@@ -47,7 +47,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import date
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/utah.py
+++ b/calendra/usa/utah.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/vermont.py
+++ b/calendra/usa/vermont.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import TUE
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/virginia.py
+++ b/calendra/usa/virginia.py
@@ -16,7 +16,7 @@ day by implementing the following class:
 
 """
 from ..core import WED, FRI
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/washington.py
+++ b/calendra/usa/washington.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/west_virginia.py
+++ b/calendra/usa/west_virginia.py
@@ -17,7 +17,7 @@ to include them, you may just have to create a class like this:
 """
 from datetime import date
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/wisconsin.py
+++ b/calendra/usa/wisconsin.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/calendra/usa/wyoming.py
+++ b/calendra/usa/wyoming.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..registry import iso_register
+from ..registry_tools import iso_register
 from .core import UnitedStates
 
 

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -25,6 +25,8 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 
 The `registry.region_registry` is an `OrderedDict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
 
+**Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
+
 ## Retrieve a collection of regions
 
 Let's say you'd need only a subset of the ISO registry. For example, France, Switzerland and Canada calendars. You can use the method `items()` to filter only the calendars you want.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
 	pyCalverter
 	more_itertools
 	ephem
+	pyluach
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,12 @@ import setuptools
 setuptools.setup(
     requires=[
         'pyluach',
-    ]
+    ],
+    # install_requires=[
+    #    'pandas',
+    #    'pytest-cov',
+    #    'pytest-flake8',
+    # ],
 )
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,5 @@
 
 import setuptools
 
-
 if __name__ == "__main__":
-    setuptools.setup(
-        use_scm_version=True,
-        requires=[
-            'pyluach',
-        ],
-        tests_require=[
-            'pandas',
-            'pytest-cov',
-            'pytest-flake8',
-        ],
-    )
+    setuptools.setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -2,5 +2,11 @@
 
 import setuptools
 
+setuptools.setup(
+    requires=[
+        'pyluach',
+    ]
+)
+
 if __name__ == "__main__":
     setuptools.setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ setuptools.setup(
     requires=[
         'pyluach',
     ],
-    # install_requires=[
-    #    'pandas',
-    #    'pytest-cov',
-    #    'pytest-flake8',
-    # ],
+    tests_require=[
+        'pandas',
+        'pytest-cov',
+        'pytest-flake8',
+    ],
 )
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,16 @@
 
 import setuptools
 
-setuptools.setup(
-    requires=[
-        'pyluach',
-    ],
-    tests_require=[
-        'pandas',
-        'pytest-cov',
-        'pytest-flake8',
-    ],
-)
 
 if __name__ == "__main__":
-    setuptools.setup(use_scm_version=True)
+    setuptools.setup(
+        use_scm_version=True,
+        requires=[
+            'pyluach',
+        ],
+        tests_require=[
+            'pandas',
+            'pytest-cov',
+            'pytest-flake8',
+        ],
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ minversion = 2.4
 [testenv]
 deps =
 	setuptools>=31.0.1
+	pyluach
 commands =
 	pytest {posargs}
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ minversion = 2.4
 [testenv]
 deps =
 	setuptools>=31.0.1
-	pyluach
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
This relates to #8. This is not yet ready to merge, see notes below regarding tests and files which need specific review.

- [n/a] Tests with a significant number of years to be tested for your calendar.
- [yes] Changelog amended with a mention describing your changes.

I've performed the merge, but my packaging skills are not up to getting the tests running (either `tox` or `make test`). I *am* able to:

- `sudo make install`
- Run a basic python3 test by hand:
```
$ python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from calendra.europe import united_kingdom
>>> foo = united_kingdom.UnitedKingdom()#.get_calendar_holidays(2020)
>>> foo.get_early_may_bank_holiday(2020)
Holiday(2020, 5, 8)

```

I would appreciate help getting the tests/tox to run. Also, the following files deserve closer review:

- travis.yml is unchanged because I don't know Travis.
- Contributing.* because I added a section on syncing.
- CHANGES.rst because I added all the revision history.
- tox.ini is unchanged because I don't know tox.
- calendra/united_kindom.py because this was by far the most complicated merge.
- calendra/usa/core.py because this was the second significant merge.
- registry.py because I had to set load_standard_modules=False, and keep the old imports. I was not able to reconcile how to make the paths/imports work.

