### PR TITLE
Sync workalendar 7 0 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-v7.0.0
+v5.0.0
 ------
 
 Incorporate changes from workalendar v7.0.0 (2019-09-20)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,24 @@
+v7.0.0
+------
+
+Incorporate changes from workalendar v7.0.0 (2019-09-20)
+
+- Drop `ephem` astronomical calculation library, in favor of `skyfield` and `skyfield-data` for providing minimal data files to enable computation (#302, #348). Many thanks to @GammaSagittarii for the tremendous help on finding the right way to compute Chinese Solar Terms. Also thanks to @antvig and @DainDwarf for testing the beta version (#398).
+
+Incorporate changes from workalendar v6.0.1 (2019-09-17)
+
+- Fix Turkey Republic Day (#399, thx to @mhmtozc & @Natim).
+
+Incorporate changes from workalendar v6.0.0 (2019-08-02)
+
+- **Deprecation Notice:** *The global ISO registry now returns plain `dict` objects from its various methods.*
+- Global registry now returns plain built-in dicts (#375).
+- Removed `EphemMixin` in favor of astronomical functions (#302).
+- Added first day counting when computing working_days delta (#393), thx @Querdos.
+
+Incorporate changes from workalendar v5.2.3 (2019-07-11)
+- Fix Romania, make sure Easter and related holidays are calculated using the Orthodox calendar, thx to @KidkArolis (#389).
+
 
 v4.0.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -84,10 +84,9 @@ For a more complete documentation and advanced usage, go to
 External dependencies
 =====================
 
-You may want to install ``python-dev`` and/or ``python3-dev`` on your machine to
-either run the installation or run tests via tox.
+Calendra has been tested on Python 2.7, 3.5, 3.6, 3.7.
 
-Workalendar has been tested on Python 2.7, 3.5, 3.6, 3.7.
+If you're using wheels, you should be fine without having to install extra system packages. As of ``v7.0.0``, we have dropped ``ephem`` as a dependency for computing astronomical ephemeris in favor of ``skyfield``. So if you had any trouble because of this new dependency, during the installation or at runtime, `do not hesitate to file an issue <https://github.com/peopledoc/workalendar/issues/>`_.
 
 Tests
 =====

--- a/calendra/asia/hong_kong.py
+++ b/calendra/asia/hong_kong.py
@@ -4,14 +4,13 @@ from __future__ import (absolute_import, division, print_function,
 
 from datetime import timedelta
 
-from ..core import ChineseNewYearCalendar, WesternCalendar
-from ..core import ChristianMixin, EphemMixin
+from ..core import ChineseNewYearCalendar, WesternCalendar, ChristianMixin
+from ..astronomy import solar_term
 from ..registry_tools import iso_register
 
 
 @iso_register('HK')
-class HongKong(EphemMixin, WesternCalendar,
-               ChineseNewYearCalendar, ChristianMixin):
+class HongKong(WesternCalendar, ChineseNewYearCalendar, ChristianMixin):
     "Hong Kong"
     include_good_friday = True
     include_easter_saturday = True
@@ -45,7 +44,7 @@ class HongKong(EphemMixin, WesternCalendar,
             self.shift_start_cny_sunday = True
 
         days = super(HongKong, self).get_variable_days(year)
-        chingming = EphemMixin.solar_term(self, year, 15, 'Asia/Hong_Kong')
+        chingming = solar_term(year, 15, 'Asia/Hong_Kong')
         dupe_holiday = [chingming for day in days if chingming == day[0]]
         if dupe_holiday:
             # Roll Chingming forward a day as it clashes with another holiday

--- a/calendra/asia/japan.py
+++ b/calendra/asia/japan.py
@@ -3,13 +3,14 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from datetime import date
 
-from ..core import MON, EphemMixin
+from ..core import MON
 from ..core import WesternCalendar
+from ..astronomy import calculate_equinoxes
 from ..registry_tools import iso_register
 
 
 @iso_register('JP')
-class Japan(WesternCalendar, EphemMixin):
+class Japan(WesternCalendar):
     "Japan"
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (
@@ -59,7 +60,7 @@ class Japan(WesternCalendar, EphemMixin):
     def get_variable_days(self, year):
         # usual variable days
         days = super(Japan, self).get_variable_days(year)
-        equinoxes = self.calculate_equinoxes(year, 'Asia/Tokyo')
+        equinoxes = calculate_equinoxes(year, 'Asia/Tokyo')
         coming_of_age_day = Japan.get_nth_weekday_in_month(year, 1, MON, 2)
         marine_day = Japan.get_nth_weekday_in_month(year, 7, MON, 3)
         respect_for_the_aged = Japan.get_nth_weekday_in_month(year, 9, MON, 3)

--- a/calendra/asia/taiwan.py
+++ b/calendra/asia/taiwan.py
@@ -3,12 +3,12 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from ..core import ChineseNewYearCalendar, WesternCalendar
-from ..core import EphemMixin
+from ..astronomy import solar_term
 from ..registry_tools import iso_register
 
 
 @iso_register('TW')
-class Taiwan(EphemMixin, ChineseNewYearCalendar, WesternCalendar):
+class Taiwan(ChineseNewYearCalendar, WesternCalendar):
     "Taiwan (Republic of China)"
     FIXED_HOLIDAYS = (
         WesternCalendar.FIXED_HOLIDAYS +
@@ -25,7 +25,7 @@ class Taiwan(EphemMixin, ChineseNewYearCalendar, WesternCalendar):
         days = super(Taiwan, self).get_variable_days(year)
         # Qingming begins when the sun reaches the celestial
         # longitude of 15° (usually around April 4th or 5th)
-        qingming = EphemMixin.solar_term(self, year, 15, 'Asia/Taipei')
+        qingming = solar_term(year, 15, 'Asia/Taipei')
 
         days.extend([
             (

--- a/calendra/astronomy.py
+++ b/calendra/astronomy.py
@@ -1,0 +1,126 @@
+"""
+Astronomical functions
+"""
+from math import pi, radians
+import pytz
+from skyfield.api import Loader
+from skyfield import almanac
+from skyfield_data import get_skyfield_data_path
+from datetime import date, timedelta
+
+
+# Parameter for the newton method to converge towards the closest solution
+# to the function. By default it'll be an approximation of a 10th of a second.
+hour = 1. / 24.
+minute = hour / 60.
+second = minute / 60.
+newton_precision = second / 10.
+
+# ``math.tau`` appears only in Python 3.6+
+tau = 2 * pi
+
+
+def calculate_equinoxes(year, timezone='UTC'):
+    """ calculate equinox with time zone """
+    tz = pytz.timezone(timezone)
+
+    load = Loader(get_skyfield_data_path())
+    ts = load.timescale()
+    planets = load('de421.bsp')
+
+    t0 = ts.utc(year, 1, 1)
+    t1 = ts.utc(year, 12, 31)
+    datetimes, _ = almanac.find_discrete(t0, t1, almanac.seasons(planets))
+    vernal_equinox = datetimes[0].astimezone(tz).date()
+    autumn_equinox = datetimes[2].astimezone(tz).date()
+    return vernal_equinox, autumn_equinox
+
+
+def get_current_longitude(current_date, earth, sun):
+    """
+    Return the ecliptic longitude, in radians.
+    """
+    astrometric = earth.at(current_date).observe(sun)
+    latitude, longitude, _ = astrometric.ecliptic_latlon(epoch='date')
+    return longitude.radians
+
+
+def newton(f, x0, x1, precision=newton_precision):
+    """Return an x-value at which the given function reaches zero.
+
+    Stops and declares victory once the x-value is within ``precision``
+    of the solution, which defaults to a half-second of clock time.
+
+    """
+    f0, f1 = f(x0), f(x1)
+    while f1 and abs(x1 - x0) > precision and f1 != f0:
+        new_x1 = x1 + (x1 - x0) / (f0 / f1 - 1)
+        x0, x1 = x1, new_x1
+        f0, f1 = f1, f(x1)
+    return x1
+
+
+def solar_term(year, degrees, timezone='UTC'):
+    """
+    Returns the date of the solar term for the given longitude
+    and the given year.
+
+    Solar terms are used for Chinese and Taiwanese holidays
+    (e.g. Qingming Festival in Taiwan).
+
+    More information:
+    - https://en.wikipedia.org/wiki/Solar_term
+    - https://en.wikipedia.org/wiki/Qingming
+
+    This function is adapted from the following topic:
+    https://answers.launchpad.net/pyephem/+question/110832
+    """
+    # Target angle as radians
+    target_angle = radians(degrees)
+
+    load = Loader(get_skyfield_data_path())
+    planets = load('de421.bsp')
+    earth = planets['earth']
+    sun = planets['sun']
+    ts = load.timescale()
+    tz = pytz.timezone(timezone)
+
+    jan_first = ts.utc(date(year, 1, 1))
+    current_longitude = get_current_longitude(jan_first, earth, sun)
+
+    # Find approximately the right time of year.
+    difference = (target_angle - current_longitude) % tau
+    # Here we have an approximation of the number of julian days to go
+    date_delta = 365.25 * difference / tau
+    # convert to "tt" and reconvert it back to a Time object
+    t0 = ts.tt_jd(jan_first.tt + date_delta)
+
+    def f(t):
+        # We've got a float which is the `tt`
+        sky_tt = ts.tt_jd(t)
+        longitude = get_current_longitude(sky_tt, earth, sun)
+        result = target_angle - longitude
+        if result > pi:
+            result = result - pi
+        elif result < -pi:
+            result = result + pi
+        return result
+
+    # Using datetimes to compute the next step date
+    t0_plus_one_minute = t0.utc_datetime() + timedelta(minutes=1)
+    # Back to Skyfield Time objects
+    t0_plus_one_minute = ts.utc(t0_plus_one_minute)
+
+    # Julian day for the starting date
+    t0 = t0.tt
+    # Adding one minute to have a second boundary
+    t0_plus_one_minute = t0_plus_one_minute.tt
+    # Newton method to converge towards the target angle
+    t = newton(f, t0, t0_plus_one_minute)
+    # Here we have a float to convert to julian days.
+    t = ts.tt_jd(t)
+    # To convert to datetime
+    t = t.utc_datetime()
+    # Convert in the timezone
+    result = t.astimezone(tz)
+    return result.date()

--- a/calendra/core.py
+++ b/calendra/core.py
@@ -472,9 +472,10 @@ class Calendar(object):
 
         Example:
 
+        >>> from dateutil.parser import parse
         >>> cal = France()
-        >>> day1 = parse('09/05/2018 00:01', dayfirst=True)
-        >>> day2 = parse('10/05/2018 19:01', dayfirst=True) # holiday in france
+        >>> day_1 = parse('09/05/2018 00:01', dayfirst=True)
+        >>> day_2 = parse('10/05/2018 19:01', dayfirst=True) # holiday in france
         >>> cal.get_working_days_delta(day_1, day_2)
         0
 

--- a/calendra/core.py
+++ b/calendra/core.py
@@ -7,10 +7,7 @@ import warnings
 import itertools
 from calendar import monthrange
 from datetime import date, timedelta, datetime
-from math import pi
 
-import ephem
-import pytz
 from calverter import Calverter
 from dateutil import easter
 from lunardate import LunarDate
@@ -446,7 +443,7 @@ class Calendar(object):
         day = day + timedelta(days=day_delta)
         return day
 
-    def get_working_days_delta(self, start, end):
+    def get_working_days_delta(self, start, end, include_start=False):
         """
         Return the number of working day between two given dates.
         The order of the dates provided doesn't matter.
@@ -468,6 +465,21 @@ class Calendar(object):
 
         This method should even work if your ``start`` and ``end`` arguments
         are datetimes.
+
+        By default, if the day after you start is not a working day,
+        the count will start at 0. If include_start is set to true,
+        this day will be taken into account.
+
+        Example:
+
+        >>> cal = France()
+        >>> day1 = parse('09/05/2018 00:01', dayfirst=True)
+        >>> day2 = parse('10/05/2018 19:01', dayfirst=True) # holiday in france
+        >>> cal.get_working_days_delta(day_1, day_2)
+        0
+
+        >>> cal.get_working_days_delta(day_1, day_2, include_start=True)
+        1
         """
         start = cleaned_date(start)
         end = cleaned_date(end)
@@ -477,8 +489,9 @@ class Calendar(object):
 
         if start > end:
             start, end = end, start
+
         # Starting count here
-        count = 0
+        count = 1 if include_start and self.is_working_day(start) else 0
         while start < end:
             start += timedelta(days=1)
             if self.is_working_day(start):
@@ -795,64 +808,6 @@ class ChineseNewYearCalendar(LunarCalendar):
             for day_shifted in self.get_shifted_holidays(days_to_inspect):
                 days.append(day_shifted)
         return days
-
-
-class EphemMixin(LunarCalendar):
-    def calculate_equinoxes(self, year, timezone='UTC'):
-        """ calculate equinox with time zone """
-
-        tz = pytz.timezone(timezone)
-
-        d1 = ephem.next_equinox(str(year))
-        d = ephem.Date(str(d1))
-        equinox1 = d.datetime() + tz.utcoffset(d.datetime())
-
-        d2 = ephem.next_equinox(d1)
-        d = ephem.Date(str(d2))
-        equinox2 = d.datetime() + tz.utcoffset(d.datetime())
-
-        return (equinox1.date(), equinox2.date())
-
-    def solar_term(self, year, degrees, timezone='UTC'):
-        """
-        Returns the date of the solar term for the given longitude
-        and the given year.
-
-        Solar terms are used for Chinese and Taiwanese holidays
-        (e.g. Qingming Festival in Taiwan).
-
-        More information:
-        - https://en.wikipedia.org/wiki/Solar_term
-        - https://en.wikipedia.org/wiki/Qingming
-
-        This function is adapted from the following topic:
-        https://answers.launchpad.net/pyephem/+question/110832
-        """
-        twopi = 2 * pi
-        tz = pytz.timezone(timezone)
-
-        # Find out the sun's current longitude.
-
-        sun = ephem.Sun(ephem.Date(str(year)))
-        current_longitude = sun.hlong - pi
-
-        # Find approximately the right time of year.
-
-        target_longitude = degrees * ephem.degree
-        difference = (target_longitude - current_longitude) % twopi
-        t0 = ephem.Date(str(year)) + 365.25 * difference / twopi
-
-        # Zero in on the exact moment.
-
-        def f(t):
-            sun.compute(t)
-            longitude = sun.hlong - pi
-            return ephem.degrees(target_longitude - longitude).znorm
-
-        d = ephem.Date(ephem.newton(f, t0, t0 + ephem.minute))
-        solar_term = d.datetime() + tz.utcoffset(d.datetime())
-
-        return solar_term.date()
 
 
 class CalverterMixin(Calendar):

--- a/calendra/europe/romania.py
+++ b/calendra/europe/romania.py
@@ -6,7 +6,7 @@ from ..registry_tools import iso_register
 
 
 @iso_register('RO')
-class Romania(WesternCalendar, OrthodoxMixin):
+class Romania(OrthodoxMixin, WesternCalendar):
     'Romania'
 
     FIXED_HOLIDAYS = WesternCalendar.FIXED_HOLIDAYS + (

--- a/calendra/europe/turkey.py
+++ b/calendra/europe/turkey.py
@@ -23,7 +23,7 @@ class Turkey(WesternCalendar, IslamicMixin):
         (5, 19, "Commemoration of Atatürk, Youth and Sports Day"),
         (7, 15, "Democracy and National Unity Day"),
         (8, 30, "Victory Day"),
-        (9, 29, "Republic Day"),
+        (10, 29, "Republic Day"),
     )
 
     def get_delta_islamic_holidays(self, year):

--- a/calendra/registry_tools.py
+++ b/calendra/registry_tools.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import warnings
-from collections import OrderedDict
 from importlib import import_module
 
 
@@ -31,12 +29,7 @@ class IsoRegistry(object):
     )
 
     def __init__(self, load_standard_modules=False):
-        warnings.warn(
-            "The use of ``OrderedDict`` objects in the registry feature is "
-            "about to be deprecated, in favor of plain ``dict`` objects",
-            DeprecationWarning
-        )
-        self.region_registry = OrderedDict()
+        self.region_registry = dict()
         if load_standard_modules:
             for module_name in self.STANDARD_MODULES:
                 module = 'calendra.{}'.format(module_name)
@@ -101,7 +94,7 @@ class IsoRegistry(object):
         :return dict where keys are ISO codes strings
         and values are calendar classes
         """
-        items = OrderedDict()
+        items = dict()
         for key, value in self.region_registry.items():
             code_elements, is_subregion = self._code_elements(key)
             if is_subregion and code_elements[0] == iso_code:
@@ -119,7 +112,7 @@ class IsoRegistry(object):
         :return dict where keys are ISO codes strings
         and values are calendar classes
         """
-        items = OrderedDict()
+        items = dict()
         for code in region_codes:
             try:
                 items[code] = self.region_registry[code]

--- a/calendra/tests/test_astronomy.py
+++ b/calendra/tests/test_astronomy.py
@@ -1,0 +1,29 @@
+from datetime import date
+
+from workalendar.astronomy import calculate_equinoxes, solar_term
+
+
+def test_calculate_some_equinoxes():
+    assert calculate_equinoxes(2010) == (date(2010, 3, 20), date(2010, 9, 23))
+    assert calculate_equinoxes(2010, 'Asia/Taipei') == (
+        date(2010, 3, 21), date(2010, 9, 23)
+    )
+    assert calculate_equinoxes(2013) == (date(2013, 3, 20), date(2013, 9, 22))
+    assert calculate_equinoxes(2014) == (date(2014, 3, 20), date(2014, 9, 23))
+    assert calculate_equinoxes(2020) == (date(2020, 3, 20), date(2020, 9, 22))
+
+
+def test_qingming_festivals():
+    assert solar_term(2001, 15) == date(2001, 4, 4)
+    assert solar_term(2001, 15, 'Asia/Taipei') == date(2001, 4, 5)
+    assert solar_term(2011, 15) == date(2011, 4, 5)
+    assert solar_term(2014, 15) == date(2014, 4, 4)
+    assert solar_term(2016, 15) == date(2016, 4, 4)
+    assert solar_term(2017, 15) == date(2017, 4, 4)
+
+
+def test_qingming_festivals_hk():
+    assert solar_term(2018, 15, 'Asia/Hong_Kong') == date(2018, 4, 5)
+    assert solar_term(2019, 15, 'Asia/Hong_Kong') == date(2019, 4, 5)
+    assert solar_term(2020, 15, 'Asia/Hong_Kong') == date(2020, 4, 4)
+    assert solar_term(2021, 15, 'Asia/Hong_Kong') == date(2021, 4, 4)

--- a/calendra/tests/test_astronomy.py
+++ b/calendra/tests/test_astronomy.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from workalendar.astronomy import calculate_equinoxes, solar_term
+from ..astronomy import calculate_equinoxes, solar_term
 
 
 def test_calculate_some_equinoxes():

--- a/calendra/tests/test_core.py
+++ b/calendra/tests/test_core.py
@@ -6,11 +6,10 @@ import dateutil.relativedelta as rd
 import pandas
 
 from . import GenericCalendarTest
-from ..core import MON, TUE, THU, FRI, WED, SAT, SUN
 from ..core import Calendar, LunarCalendar, WesternCalendar
-from ..core import IslamicMixin, JalaliMixin, ChristianMixin
-from ..core import EphemMixin
 from ..core import Holiday
+from ..core import IslamicMixin, JalaliMixin, ChristianMixin
+from ..core import MON, TUE, THU, FRI, WED, SAT, SUN
 from ..exceptions import UnsupportedDateType
 
 
@@ -294,50 +293,6 @@ class JalaliMixinTest(GenericCalendarTest):
         self.assertEquals(len(days), 365)
 
 
-class EphemMixinTest(GenericCalendarTest):
-    cal_class = EphemMixin
-
-    def test_calculate_some_equinoxes(self):
-        self.assertEquals(
-            self.cal.calculate_equinoxes(2010),
-            (date(2010, 3, 20), date(2010, 9, 23))
-        )
-        self.assertEquals(
-            self.cal.calculate_equinoxes(2010, 'Asia/Taipei'),
-            (date(2010, 3, 21), date(2010, 9, 23))
-        )
-        self.assertEquals(
-            self.cal.calculate_equinoxes(2013),
-            (date(2013, 3, 20), date(2013, 9, 22))
-        )
-        self.assertEquals(
-            self.cal.calculate_equinoxes(2014),
-            (date(2014, 3, 20), date(2014, 9, 23))
-        )
-        self.assertEquals(
-            self.cal.calculate_equinoxes(2020),
-            (date(2020, 3, 20), date(2020, 9, 22))
-        )
-
-    def test_qingming_festivals(self):
-        self.assertEquals(
-            self.cal.solar_term(2001, 15),
-            date(2001, 4, 4)
-        )
-        self.assertEquals(
-            self.cal.solar_term(2001, 15, 'Asia/Taipei'),
-            date(2001, 4, 5)
-        )
-        self.assertEquals(
-            self.cal.solar_term(2011, 15),
-            date(2011, 4, 5)
-        )
-        self.assertEquals(
-            self.cal.solar_term(2014, 15),
-            date(2014, 4, 4)
-        )
-
-
 class MockChristianCalendar(WesternCalendar, ChristianMixin):
     pass
 
@@ -507,6 +462,20 @@ class WorkingDaysDeltatest(TestCase):
         # No difference if you swap the two dates
         delta = cal.get_working_days_delta(day2, day1)
         self.assertEqual(delta, 2)
+
+    def test_with_including_first_day(self):
+        # linked to #393
+        cal = MockChristianCalendar()
+        day1 = date(2018, 12, 24)  # December 24th: not holiday so working day
+        day2 = date(2018, 12, 25)  # December 25th: Christmas
+
+        # not including the first day, should return 0
+        delta = cal.get_working_days_delta(day1, day2)
+        self.assertEqual(delta, 0)
+
+        # including the first day, should return 1
+        delta = cal.get_working_days_delta(day1, day2, include_start=True)
+        self.assertEqual(delta, 1)
 
 
 class NoDocstring(Calendar):

--- a/calendra/tests/test_europe.py
+++ b/calendra/tests/test_europe.py
@@ -813,6 +813,24 @@ class Romania(GenericCalendarTest):
         self.assertIn(date(2017, 12, 25), holidays)  # Crăciunul Christmas
         self.assertIn(date(2017, 12, 26), holidays)  # Crăciunul Christmas
 
+    def test_year_2019(self):
+        holidays = self.cal.holidays_set(2019)
+        self.assertIn(date(2019, 1, 1), holidays)  # Anul Nou New Year's Day
+        self.assertIn(date(2019, 1, 2), holidays)  # Anul Nou Day after New Yr
+        self.assertIn(date(2019, 1, 24), holidays)  # Unirea Principatelor Rom
+        self.assertIn(date(2019, 4, 26), holidays)  # Orthodox Good Fri
+        self.assertIn(date(2019, 4, 28), holidays)  # Orthodox Easter Sun
+        self.assertIn(date(2019, 4, 29), holidays)  # Orthodox Easter Mon
+        self.assertIn(date(2019, 5, 1), holidays)  # Ziua Muncii Labour Day
+        self.assertIn(date(2019, 6, 1), holidays)  # Ziua Copilului Children's
+        self.assertIn(date(2019, 6, 16), holidays)  # Pentecost
+        self.assertIn(date(2019, 6, 17), holidays)  # Whit Monday
+        self.assertIn(date(2019, 8, 15), holidays)  # Adormirea Maicii Domnului
+        self.assertIn(date(2019, 11, 30), holidays)  # Sfântul Andrei St. Andre
+        self.assertIn(date(2019, 12, 1), holidays)  # Ziua Națională/Marea Unir
+        self.assertIn(date(2019, 12, 25), holidays)  # Crăciunul Christmas
+        self.assertIn(date(2019, 12, 26), holidays)  # Crăciunul Christmas
+
 
 class Russia(GenericCalendarTest):
     cal_class = Russia

--- a/calendra/tests/test_turkey.py
+++ b/calendra/tests/test_turkey.py
@@ -32,7 +32,7 @@ class TurkeyTest(GenericCalendarTest):
         # 6. Victory Day
         self.assertIn(date(2014, 8, 30), holidays)
         # 7. Republic Day
-        self.assertIn(date(2014, 9, 29), holidays)
+        self.assertIn(date(2014, 10, 29), holidays)
 
     def test_year_2015(self):
         holidays = self.cal.holidays_set(2015)
@@ -50,7 +50,7 @@ class TurkeyTest(GenericCalendarTest):
         # 6. Victory Day
         self.assertIn(date(2015, 8, 30), holidays)
         # 7. Republic Day
-        self.assertIn(date(2015, 9, 29), holidays)
+        self.assertIn(date(2015, 10, 29), holidays)
 
     def test_year_2019(self):
         holidays = self.cal.holidays_set(2019)
@@ -68,7 +68,7 @@ class TurkeyTest(GenericCalendarTest):
         # 6. Victory Day
         self.assertIn(date(2019, 8, 30), holidays)
         # 7. Republic Day
-        self.assertIn(date(2019, 9, 29), holidays)
+        self.assertIn(date(2019, 10, 29), holidays)
 
         # Religious days
         # Ramadan Feast - 3 days

--- a/docs/iso-registry.md
+++ b/docs/iso-registry.md
@@ -9,7 +9,7 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 ```python
 >>> from workalendar.registry import registry
 >>> for code, calendar_class in registry.region_registry.items():
-...     print(u"`{}` is code for '{}'".format(code, calendar_class.name))
+...     print("`{}` is code for '{}'".format(code, calendar_class.name))
 `AT` is code for 'Austria'
 `BE` is code for 'Belgium'
 `BG` is code for 'Bulgaria'
@@ -23,9 +23,7 @@ As of version 3.0 (August/September 2018), we have introduced a global calendar 
 ... continued
 ```
 
-The `registry.region_registry` is an `OrderedDict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
-
-**Deprecation Warning:** *Currently the registry returns `OrderedDict` objects when you're querying for regions or subregions. Expect that the next release will preferrably return plain'ol' `dict` objects. If your scripts rely on the order of the objects returned, you'll have to sort them yourself.*
+The `registry.region_registry` is a `dict` object, with the ISO code as a key, and the calendar class as the value. As a "workalendar standard", **every** calendar in the registry has a `name` property (derived from the docstring), so you'd probably be able to build a user-friendly list of available calendars, for a dropdown list, for example.
 
 ## Retrieve a collection of regions
 
@@ -33,32 +31,32 @@ Let's say you'd need only a subset of the ISO registry. For example, France, Swi
 
 ```python
 >>> registry.items(['FR', 'CH', 'CA'])
-OrderedDict([('FR', workalendar.europe.france.France),
-             ('CH', workalendar.europe.switzerland.Switzerland),
-             ('CA', workalendar.america.canada.Canada)])
+{'FR': <class 'workalendar.europe.france.France'>,
+ 'CH': <class 'workalendar.europe.switzerland.Switzerland'>,
+ 'CA': <class 'workalendar.america.canada.Canada'>}
 ```
 
 Also, if you want those regions **and** their subregions, you can use the `include_subregions` flag:
 
 ```python
 >>> registry.items(['FR', 'CH', 'CA'], include_subregions=True)
-OrderedDict([('FR', workalendar.europe.france.France),
-             ('CH', workalendar.europe.switzerland.Switzerland),
-             (u'CH-VD', workalendar.europe.switzerland.Vaud),
-             ('CA', workalendar.america.canada.Canada),
-             (u'CA-ON', workalendar.america.canada.Ontario),
-             (u'CA-QC', workalendar.america.canada.Quebec),
-             (u'CA-BC', workalendar.america.canada.BritishColumbia),
-             (u'CA-AB', workalendar.america.canada.Alberta),
-             (u'CA-SK', workalendar.america.canada.Saskatchewan),
-             (u'CA-MB', workalendar.america.canada.Manitoba),
-             (u'CA-NB', workalendar.america.canada.NewBrunswick),
-             (u'CA-NS', workalendar.america.canada.NovaScotia),
-             (u'CA-PE', workalendar.america.canada.PrinceEdwardIsland),
-             (u'CA-NL', workalendar.america.canada.Newfoundland),
-             (u'CA-YT', workalendar.america.canada.Yukon),
-             (u'CA-NT', workalendar.america.canada.NorthwestTerritories),
-             (u'CA-NU', workalendar.america.canada.Nunavut)])
+{'CA': <class 'workalendar.america.canada.Canada'>,
+ 'CA-AB': <class 'workalendar.america.canada.Alberta'>,
+ 'CA-BC': <class 'workalendar.america.canada.BritishColumbia'>,
+ 'CA-MB': <class 'workalendar.america.canada.Manitoba'>,
+ 'CA-NB': <class 'workalendar.america.canada.NewBrunswick'>,
+ 'CA-NL': <class 'workalendar.america.canada.Newfoundland'>,
+ 'CA-NS': <class 'workalendar.america.canada.NovaScotia'>,
+ 'CA-NT': <class 'workalendar.america.canada.NorthwestTerritories'>,
+ 'CA-NU': <class 'workalendar.america.canada.Nunavut'>,
+ 'CA-ON': <class 'workalendar.america.canada.Ontario'>,
+ 'CA-PE': <class 'workalendar.america.canada.PrinceEdwardIsland'>,
+ 'CA-QC': <class 'workalendar.america.canada.Quebec'>,
+ 'CA-SK': <class 'workalendar.america.canada.Saskatchewan'>,
+ 'CA-YT': <class 'workalendar.america.canada.Yukon'>,
+ 'CH': <class 'workalendar.europe.switzerland.Switzerland'>,
+ 'CH-VD': <class 'workalendar.europe.switzerland.Vaud'>,
+ 'FR': <class 'workalendar.europe.france.France'>}
 ```
 
 *Note*: if any of the codes is unknown, this function won't raise an error.
@@ -73,15 +71,15 @@ Let's say that we only know the ISO code for Switzerland (`CH`). If we want to c
 >>> calendar = CalendarClass()
 >>> calendar.holidays(2018)
 [(datetime.date(2018, 1, 1), 'New year'),
- (datetime.date(2018, 1, 2), u"Berchtold's Day"),
+ (datetime.date(2018, 1, 2), "Berchtold's Day"),
  (datetime.date(2018, 3, 30), 'Good Friday'),
  (datetime.date(2018, 4, 1), 'Easter Sunday'),
  (datetime.date(2018, 4, 2), 'Easter Monday'),
- (datetime.date(2018, 5, 1), u'Labour Day'),
+ (datetime.date(2018, 5, 1), 'Labour Day'),
  (datetime.date(2018, 5, 10), 'Ascension Thursday'),
  (datetime.date(2018, 5, 20), 'Whit Sunday'),
  (datetime.date(2018, 5, 21), 'Whit Monday'),
- (datetime.date(2018, 8, 1), u'National Holiday'),
+ (datetime.date(2018, 8, 1), 'National Holiday'),
  (datetime.date(2018, 12, 25), 'Christmas Day'),
  (datetime.date(2018, 12, 26), 'Boxing Day')]
 ```
@@ -95,17 +93,16 @@ As an example, the United States of America, or Australia and others are divided
 
 ```python
 >>> registry.get_subregions('AU')
-OrderedDict([(u'AU-ACT',
-              workalendar.oceania.australia.AustralianCapitalTerritory),
-             (u'AU-NSW', workalendar.oceania.australia.NewSouthWales),
-             (u'AU-NT', workalendar.oceania.australia.NorthernTerritory),
-             (u'AU-QLD', workalendar.oceania.australia.Queensland),
-             (u'AU-SA', workalendar.oceania.australia.SouthAustralia),
-             (u'AU-TAS', workalendar.oceania.australia.Tasmania),
-             (u'AU-VIC', workalendar.oceania.australia.Victoria),
-             (u'AU-WA', workalendar.oceania.australia.WesternAustralia)])
+{'AU-ACT': <class 'workalendar.oceania.australia.AustralianCapitalTerritory'>,
+ 'AU-NSW': <class 'workalendar.oceania.australia.NewSouthWales'>,
+ 'AU-NT': <class 'workalendar.oceania.australia.NorthernTerritory'>,
+ 'AU-QLD': <class 'workalendar.oceania.australia.Queensland'>,
+ 'AU-SA': <class 'workalendar.oceania.australia.SouthAustralia'>,
+ 'AU-TAS': <class 'workalendar.oceania.australia.Tasmania'>,
+ 'AU-VIC': <class 'workalendar.oceania.australia.Victoria'>,
+ 'AU-WA': <class 'workalendar.oceania.australia.WesternAustralia'>}
 ```
 
-*Note*: this function will return an empty `OrderedDict` if the code is unknown.
+*Note*: this function will return an empty `dict` if the code is unknown.
 
 [Home](index.md) / [Basic usage](basic.md) / [Advanced usage](advanced.md)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ install_requires =
 	pytz
 	pyCalverter
 	more_itertools
-	ephem
+	skyfield
+	skyfield-data
 	pyluach
 setup_requires = setuptools_scm >= 1.15.0
 


### PR DESCRIPTION
As requested, here is a **NOT-READY-TO-MERGE** pull request for a sync with upstream Workalendar v7.0.0.

I have reviewed the deltas, and have not seen anything of note. However, it is not ready to merge because I have been unable to do any testing as tox fails to run in some obscure way on my system:

```
$ tox
python create: /main/srhaque/.../calendra/.tox/python
Python 2.7.16
________________________________________________________________________________________ summary _________________________________________________________________________________________
  python: commands succeeded
  congratulations :)
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/__main__.py", line 4, in <module>
    tox.cmdline()
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/session/__init__.py", line 44, in cmdline
    main(args)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/session/__init__.py", line 68, in main
    exit_code = session.runcommand()
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/session/__init__.py", line 192, in runcommand
    return self.subcommand_test()
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/session/__init__.py", line 220, in subcommand_test
    run_sequential(self.config, self.venv_dict)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/session/commands/run/sequential.py", line 9, in run_sequential
    if venv.setupenv():
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/venv.py", line 594, in setupenv
    status = self.update(action=action)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox/venv.py", line 252, in update
    self.hook.tox_testenv_create(action=action, venv=self)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/pluggy/manager.py", line 92, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/pluggy/manager.py", line 86, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox_pip_version/hooks.py", line 50, in tox_testenv_create
    _testenv_create(venv, action)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox_pip_version/hooks.py", line 24, in _testenv_create
    finished = tox_testenv_create(venv, action)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox_venv/hooks.py", line 92, in tox_testenv_create
    real_executable = real_python3(config_interpreter, version_dict)
  File "/main/srhaque/kdedev/calendra/.tox/.tox/lib/python3.7/site-packages/tox_venv/hooks.py", line 67, in real_python3
    assert v1 == v2, 'Expected versions to match (%s != %s).' % (v1, v2)
AssertionError: Expected versions to match (b'Python 3.7.3\n' != b'').
```

Possibly some Python2 versus Python3 thing?