### PR TITLE
Fix floating mondays for Italy

### DIFF
--- a/calendra/europe/italy.py
+++ b/calendra/europe/italy.py
@@ -22,3 +22,4 @@ class Italy(WesternCalendar):
     include_all_saints = True
     include_boxing_day = True
     boxing_day_label = "St Stephen's Day"
+    observance_shift = None

--- a/calendra/tests/test_europe.py
+++ b/calendra/tests/test_europe.py
@@ -1020,6 +1020,12 @@ class ItalyTest(GenericCalendarTest):
         self.assertEqual(
             holidays[date(2020, 5, 1)], "International Workers' Day")
 
+    def test_workday_after_weekend_holiday(self):
+        # 2024-06-02 was on sunday
+        self.cal.is_working_day(date(2024, 6, 3))
+        # 2024-01-06 was on saturday
+        self.cal.is_working_day(date(2024, 1, 8))
+
 
 class LatviaTest(GenericCalendarTest):
 


### PR DESCRIPTION
In Italy the current general laws/contracts does not provide additional days of rest whenever an holiday occurs in the weekend (aka: floating mondays, refs #29). Any weekday from monday to friday which is not an holiday is considered a working day.

