### PR TITLE
feat: China's public holidays for 2025

### DIFF
--- a/calendra/asia/china.py
+++ b/calendra/asia/china.py
@@ -58,6 +58,14 @@ holidays = {
             'Dragon Boat Festival': [(6, 8), (6, 9), (6, 10)],
             'Mid-Autumn Festival': [(9, 15), (9, 16), (9, 17)],
         },
+    2025: {
+        'New year': [(1, 1)],
+        'Spring Festival': [(2, 4)],
+        'Ching Ming Festival': [(4, 4), (4, 5), (4, 6)],
+        'Labour Day Holiday': [(5, 1), (5, 2), (5, 3), (5, 4), (5, 5)],
+        'Dragon Boat Festival': [(5, 31), (6, 1), (6, 2)],
+        'National Day': [(10, 8)],
+    }
 }
 
 workdays = {
@@ -111,13 +119,19 @@ workdays = {
             'Mid-Autumn Festival Shift': [(9, 14)],
             'National Day Shift': [(9, 29), (10, 12)]
         },
+    2025:
+        {
+            'Spring Festival Shift': [(1, 26), (2, 8)],
+            'Labour Day Holiday Shift': [(4, 27)],
+            'National Day Shift': [(9, 28), (10, 11)],
+        }
 }
 
 
 @iso_register('CN')
 class China(ChineseNewYearCalendar):
     "China"
-    # WARNING: Support 2018-2024 currently, need update every year.
+    # WARNING: Support 2018-2025 currently, need update every year.
     shift_new_years_day = True
     include_chinese_new_year_eve = True
 

--- a/calendra/tests/test_asia.py
+++ b/calendra/tests/test_asia.py
@@ -165,6 +165,34 @@ class ChinaTest(GenericCalendarTest):
         self.assertNotIn(date(2024, 9, 29), holidays)   # National Day Shift
         self.assertNotIn(date(2024, 10, 12), holidays)  # National Day Shift
 
+    def test_year_2025(self):
+        holidays = self.cal.holidays_set(2025)
+        self.assertIn(date(2025, 1, 1), holidays)       # New Year
+        self.assertNotIn(date(2025, 1, 26), holidays)   # Spring Festival Shift
+        self.assertIn(date(2025, 1, 28), holidays)      # Spring Festival
+        self.assertIn(date(2025, 1, 29), holidays)      # Spring Festival
+        self.assertIn(date(2025, 1, 30), holidays)      # Spring Festival
+        self.assertIn(date(2025, 1, 31), holidays)      # Spring Festival
+        self.assertIn(date(2025, 2, 1), holidays)       # Spring Festival
+        self.assertIn(date(2025, 2, 2), holidays)       # Spring Festival
+        self.assertIn(date(2025, 2, 3), holidays)       # Spring Festival
+        self.assertIn(date(2025, 2, 4), holidays)       # Spring Festival
+        self.assertNotIn(date(2025, 2, 8), holidays)    # Spring Festival Shift
+        self.assertIn(date(2025, 4, 4), holidays)       # Ching Ming Festival
+        self.assertIn(date(2025, 4, 5), holidays)       # Ching Ming Festival
+        self.assertIn(date(2025, 4, 6), holidays)       # Ching Ming Festival
+        self.assertNotIn(date(2025, 4, 27), holidays)   # Labour Day Holiday Shift
+        for i in range(1, 6):
+            self.assertIn(date(2025, 5, i), holidays)       # Labour Day Holiday
+        self.assertIn(date(2025, 5, 31), holidays)      # Dragon Boat Festival
+        self.assertIn(date(2025, 6, 1), holidays)       # Dragon Boat Festival
+        self.assertIn(date(2025, 6, 2), holidays)       # Dragon Boat Festival
+        self.assertNotIn(date(2025, 9, 28), holidays)   # National Day Shift
+        for i in range(1, 9):
+            self.assertIn(date(2025, 10, i), holidays)      # Mid-Autumn Festival & National Day
+        self.assertNotIn(date(2025, 10, 11), holidays)  # National Day Shift
+
+
     def test_missing_holiday_year(self):
         save_2018 = china_holidays[2018]
         del china_holidays[2018]
@@ -177,7 +205,7 @@ class ChinaTest(GenericCalendarTest):
         with patch('warnings.warn') as patched:
             self.cal.get_calendar_holidays(year)
         patched.assert_called_with(
-            'Support years 2018-2024 currently, need update every year.'
+            'Support years 2018-2025 currently, need update every year.'
         )
 
     def test_is_working_day(self):


### PR DESCRIPTION
Notice from the China General Office of the State Council on the Arrangement of Some Holidays in 2025:
https://www.gov.cn/zhengce/content/202411/content_6986382.htm

<!-- if your contribution is a fix -->

- [x] Tests with a significant number of years to be tested for your calendar.
- [ ] Changelog amended with a mention describing your changes. **Note** *Please do NOT change the version number here. It's the project maintainers' duty.*
