### PR TITLE
Gpl issues

### DIFF
--- a/calendra/convertdate.py
+++ b/calendra/convertdate.py
@@ -1,0 +1,135 @@
+"""
+This file is part of convertdate.
+http://github.com/fitnr/convertdate
+Licensed under the MIT license:
+http://opensource.org/licenses/MIT
+Copyright (c) 2016, fitnr <fitnr@fakeisthenewreal>
+Extended by Daniel Grießhaber <dangrie158@gmail.com> to add typing information
+"""
+
+from calendar import isleap
+from math import ceil, floor
+
+
+class islamic:
+    EPOCH = 1948439.5
+
+    @classmethod
+    def from_gregorian(cls, year: int, month: int, day: int):
+        return cls.from_jd(gregorian.to_jd(year, month, day))
+
+    @classmethod
+    def to_gregorian(cls, year: int, month: int, day: int):
+        return gregorian.from_jd(cls.to_jd(year, month, day))
+
+    @classmethod
+    def to_jd(cls, year: int, month: int, day: int) -> float:
+        """Determine Julian day count from Islamic date"""
+        return (
+            day
+            + ceil(29.5 * (month - 1))
+            + (year - 1) * 354
+            + floor((3 + (11 * year)) / 30)
+            + cls.EPOCH
+        ) - 1
+
+    @classmethod
+    def from_jd(cls, jd: float):
+        """Calculate Islamic date from Julian day"""
+        jd = floor(jd) + 0.5
+        year = floor(((30 * (jd - cls.EPOCH)) + 10646) / 10631)
+        month = min(
+            12, ceil((jd - (29 + cls.to_jd(year, 1, 1))) / 29.5) + 1)
+        day = int(jd - cls.to_jd(year, month, 1)) + 1
+        return year, month, day
+
+
+class gregorian:
+    EPOCH = 1721425.5
+    YEAR_DAYS = 365
+    LEAP_CYCLE_YEARS = 4
+    LEAP_CYCLE_DAYS = 1461
+    LEAP_SUPPRESSION_YEARS = 100
+    LEAP_SUPPRESSION_DAYS = 36524
+    INTERCALATION_CYCLE_YEARS = 400
+    INTERCALATION_CYCLE_DAYS = 146097
+
+    HAVE_30_DAYS = (4, 6, 9, 11)
+
+    @classmethod
+    def legal_date(cls, year: int, month: int, day: int) -> bool:
+        """Check if this is a legal date in the Gregorian calendar"""
+        if month == 2:
+            daysinmonth = 29 if isleap(year) else 28
+        else:
+            daysinmonth = 30 if month in cls.HAVE_30_DAYS else 31
+
+        if not 0 < day <= daysinmonth:
+            raise ValueError(
+                f"Month {month} doesn't have a day {day}")
+
+        return True
+
+    @classmethod
+    def to_jd(cls, year: int, month: int, day: int) -> float:
+        """Convert gregorian date to julian day count."""
+        cls.legal_date(year, month, day)
+
+        if month <= 2:
+            leap_adj = 0
+        elif isleap(year):
+            leap_adj = -1
+        else:
+            leap_adj = -2
+
+        return (
+            cls.EPOCH
+            - 1
+            + (cls.YEAR_DAYS * (year - 1))
+            + floor((year - 1) / cls.LEAP_CYCLE_YEARS)
+            + (-floor((year - 1) / cls.LEAP_SUPPRESSION_YEARS))
+            + floor((year - 1) / cls.INTERCALATION_CYCLE_YEARS)
+            + floor((((367 * month) - 362) / 12) + leap_adj + day)
+        )
+
+    @classmethod
+    def from_jd(cls, jd: float):
+        """Return Gregorian date in a (Y, M, D) tuple"""
+        wjd = floor(jd - 0.5) + 0.5
+        depoch = wjd - cls.EPOCH
+
+        quadricent = floor(depoch / cls.INTERCALATION_CYCLE_DAYS)
+        dqc = depoch % cls.INTERCALATION_CYCLE_DAYS
+
+        cent = floor(dqc / cls.LEAP_SUPPRESSION_DAYS)
+        dcent = dqc % cls.LEAP_SUPPRESSION_DAYS
+
+        quad = floor(dcent / cls.LEAP_CYCLE_DAYS)
+        dquad = dcent % cls.LEAP_CYCLE_DAYS
+
+        yindex = floor(dquad / cls.YEAR_DAYS)
+        year = (
+            quadricent * cls.INTERCALATION_CYCLE_YEARS
+            + cent * cls.LEAP_SUPPRESSION_YEARS
+            + quad * cls.LEAP_CYCLE_YEARS
+            + yindex
+        )
+
+        if not (cent == 4 or yindex == 4):
+            year += 1
+
+        yearday = wjd - cls.to_jd(year, 1, 1)
+
+        leap = isleap(year)
+
+        if yearday < 58 + leap:
+            leap_adj = 0
+        elif leap:
+            leap_adj = 1
+        else:
+            leap_adj = 2
+
+        month = floor((((yearday + leap_adj) * 12) + 373) / 367)
+        day = int(wjd - cls.to_jd(year, month, 1)) + 1
+
+        return year, month, day

--- a/calendra/core.py
+++ b/calendra/core.py
@@ -8,9 +8,9 @@ from datetime import date, timedelta, datetime
 from pathlib import Path
 import sys
 
-import convertdate
+from . import convertdate
 from dateutil import easter
-from lunardate import LunarDate
+from lunarcalendar import Lunar
 from dateutil import relativedelta as rd
 
 from .exceptions import (
@@ -274,7 +274,7 @@ class LunarMixin:
     """
     @staticmethod
     def lunar(year, month, day):
-        return LunarDate(year, month, day).toSolarDate()
+        return Lunar(year, month, day).to_date()
 
 
 class ChineseNewYearMixin(LunarMixin):

--- a/newsfragments/40.misc.rst
+++ b/newsfragments/40.misc.rst
@@ -1,0 +1,2 @@
+vendor in GPL free version of convertdate library
+move from lunardate to lunarcalendar

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,9 @@ requires-python = ">=3.9"
 license = "MIT"
 dependencies = [
 	"python-dateutil",
-	"lunardate",
+	"LunarCalendar",
 	'backports.zoneinfo;python_version<"3.9"',
 	'tzdata;platform_system=="Windows"',
-	"convertdate",
 	"pyluach",
 	'importlib_metadata; python_version < "3.8"',
 	"more_itertools",


### PR DESCRIPTION
refs #40 


This removes the 2 tainted dependencies `convertdate` and `lunardate` as they are GPL licensed or depend on GPL licensed code.

`lunardate` is replaced by [LunarCalendar](https://github.com/wolfhong/LunarCalendar) which has the same functionality but does not depend on any GPL Code.

`convertdate` is vendored with only the necessary functionality. the full `convertdate` library depends on PyMeeus which is GPL v3, however this functionality is not used by `calendra`. Sadly, `convertdate` maintainers [made it clear that they do not care about the violation](https://github.com/fitnr/convertdate/issues/52) thus I decided to make use of the MIT License of the code and vendor it into Calendra in this PR as I do not see another way.


Let me know what you think of this approach  