### PR TITLE
Added St Brigid's Day to Ireland - Introduced in 2023

### DIFF
--- a/calendra/europe/ireland.py
+++ b/calendra/europe/ireland.py
@@ -24,9 +24,23 @@ class Ireland(WesternCalendar):
             "August Holiday"
         )
 
+    def get_st_brigids_day(self, year):
+        feb_1 = date(year, 2, 1)
+
+        # If Feb 1 is Friday, use Feb 1 itself
+        if feb_1.weekday() == 4:
+            return (feb_1, "St. Brigid's Day")
+
+        # Otherwise first Monday in February
+        return (Ireland.get_nth_weekday_in_month(year, 2, MON), "St. Brigid's Day")
+
     def get_variable_days(self, year):
         self.include_whit_monday = (year <= 1973)
         days = super().get_variable_days(year)
+
+        # St. Brigid's day, introduced in 2023
+        if year >= 2023:
+            days.append(self.get_st_brigids_day(year))
 
         # St Patrick's day
         st_patrick = date(year, 3, 17)

--- a/calendra/tests/test_europe.py
+++ b/calendra/tests/test_europe.py
@@ -1003,6 +1003,27 @@ class IrelandTest(GenericCalendarTest):
         self.assertIn(date(1977, 10, 31), holidays_1977)     # October Hol
         self.assertIn(date(1978, 10, 30), holidays_1978)
 
+    def test_st_brigids_day(self):
+        # No St Brigid's Day before 2023
+        for year in range(2010, 2023):
+            holidays = self.cal.holidays_set(year)
+            self.assertTrue(all(d.month != 2 for d in holidays))
+        # Falls on first Monday in February
+        monday_years_days = (
+            (2023, 6), (2024, 5), (2025, 3), (2026, 2),
+            (2027, 1), (2028, 7), (2029, 5), (2031, 3),
+            (2032, 2), (2033, 7), (2034, 6), (2035, 5)
+        )
+        for year, day in monday_years_days:
+            holidays = self.cal.holidays_set(year)
+            self.assertIn(date(year, 2, day), holidays)
+        # Except if 1st of Feb is Friday, then it falls on that
+        holidays_2030 = self.cal.holidays_set(2030)
+        self.assertIn(date(2030, 2, 1), holidays_2030)
+        holidays_2036 = self.cal.holidays_set(2036)
+        self.assertIn(date(2036, 2, 1), holidays_2036)
+
+
 
 class ItalyTest(GenericCalendarTest):
     cal_class = Italy

--- a/newsfragments/.feature.rst
+++ b/newsfragments/.feature.rst
@@ -1,0 +1,1 @@
+Added St Brigid's Day to 'Ireland' - Introduced in 2023


### PR DESCRIPTION
St Brigid's Day was introduced as a public holiday in Ireland in 2023.

It falls on the first Monday of each February, except when the 1st of February falls on a Friday, in which case that will be St Brigid's Day.

Source from the Irish Government:
https://www.citizensinformation.ie/en/employment/employment-rights-and-conditions/leave-and-holidays/public-holidays/#2473e9

refs #

<!-- if your contribution is a fix -->

- [X] Tests with a significant number of years to be tested for your calendar.
- [X] Create a changelog entry using [`towncrier`](https://towncrier.readthedocs.io/) (e.g. ```towncrier -c "Fixed XYZ for ``country``." $ISSUE.feature.rst```).

<!-- Release management

- Commit for the tag:
	- [ ] Edit version in setup.cfg
	- [ ] Add version in Changelog.md ; trim things
	- [ ] Push & wait for the tests to be green
	- [ ] tag me.
	- [ ] build sdist + wheel packages (``make package``)
- Back to dev commit:
	- [ ] Edit version in setup.cfg
	- [ ] Add the "master / nothing to see here" in Changelog.md
	- [ ] Push & wait for the tests to be green
- [ ] Merge --ff
- Github stuff
	- [ ] Push tag in Github
	- [ ] Edit release on Github using the changelog.
	- [ ] Delete branch
- [ ] upload release on PyPI using ``twine``
- [ ] (*optional*) Make feeback on the various PR or issues.

 -->
